### PR TITLE
Add comprehensive licensing and attribution for ZIM distribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,88 @@
+MIT License
+
+Copyright (c) 2026 StreetZIM contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+===============================================================================
+
+THIRD-PARTY DATA LICENSES
+
+The ZIM files produced by this tool contain data from the following sources,
+each subject to its own license terms:
+
+1. OpenStreetMap
+   License: Open Data Commons Open Database License (ODbL 1.0)
+   Attribution: (c) OpenStreetMap contributors
+   Details: https://www.openstreetmap.org/copyright
+
+2. Sentinel-2 Cloudless Satellite Imagery (2021)
+   Provider: EOX IT Services GmbH
+   License: Creative Commons Attribution-NonCommercial-ShareAlike 4.0
+            International (CC BY-NC-SA 4.0)
+   Attribution: Sentinel-2 cloudless - https://s2maps.eu by EOX IT Services
+                GmbH (Contains modified Copernicus Sentinel data 2021)
+   Details: https://s2maps.eu
+   NOTE: This license restricts commercial use. See README for details.
+
+3. Copernicus GLO-30 Digital Elevation Model
+   License: Copernicus Programme free and open access
+   Attribution: (c) DLR e.V. 2010-2014 and (c) Airbus Defence and Space GmbH
+                2014-2018 provided under COPERNICUS by the European Union and
+                ESA; all rights reserved
+   Details: https://dataspace.copernicus.eu
+
+4. OpenMapTiles Vector Tile Schema
+   License: Creative Commons Attribution 4.0 International (CC BY 4.0)
+   Attribution: (c) OpenMapTiles contributors
+   Details: https://openmaptiles.org/
+
+5. Wikidata
+   License: Creative Commons CC0 1.0 Universal (Public Domain Dedication)
+   Details: https://www.wikidata.org/wiki/Wikidata:Licensing
+
+6. Wikipedia Extracts
+   License: Creative Commons Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0)
+   Details: https://en.wikipedia.org/wiki/Wikipedia:Copyrights
+
+===============================================================================
+
+BUNDLED SOFTWARE LICENSES
+
+7. MapLibre GL JS
+   License: BSD 3-Clause License
+   Details: https://github.com/maplibre/maplibre-gl-js/blob/main/LICENSE.txt
+
+8. Leaflet.js (alternative viewer)
+   License: BSD 2-Clause License
+   Details: https://github.com/Leaflet/Leaflet/blob/main/LICENSE
+
+===============================================================================
+
+BUILD-TIME DEPENDENCIES (not included in ZIM output)
+
+9. libzim / python-libzim
+   License: GNU General Public License v2 (GPLv2)
+   Details: https://github.com/openzim/libzim
+   Note: Used as a build tool only. ZIM file output is data, not a
+         derivative work of libzim.
+
+10. Tilemaker
+    License: BSD 2-Clause License
+    Details: https://github.com/systemed/tilemaker

--- a/README.md
+++ b/README.md
@@ -353,7 +353,25 @@ The OpenMapTiles schema includes these layers:
 
 ## License
 
-- Tool code: MIT
-- Map data: [OpenStreetMap](https://www.openstreetmap.org/copyright) (ODbL)
-- Tile schema: [OpenMapTiles](https://openmaptiles.org/) (CC-BY 4.0)
-- MapLibre GL JS: BSD-3-Clause
+**Tool code:** MIT (see [LICENSE](LICENSE))
+
+**Data in ZIM files:**
+
+| Source | License | Attribution Required |
+|---|---|---|
+| [OpenStreetMap](https://www.openstreetmap.org/copyright) | ODbL 1.0 | (c) OpenStreetMap contributors |
+| [Sentinel-2 Cloudless](https://s2maps.eu) (satellite) | **CC BY-NC-SA 4.0** | Sentinel-2 cloudless by EOX (Contains modified Copernicus Sentinel data 2021) |
+| [Copernicus GLO-30 DEM](https://dataspace.copernicus.eu) (elevation) | Copernicus free & open | (c) DLR e.V. 2010-2014 and (c) Airbus Defence and Space GmbH 2014-2018, provided under COPERNICUS by EU and ESA |
+| [OpenMapTiles](https://openmaptiles.org/) (tile schema) | CC BY 4.0 | (c) OpenMapTiles contributors |
+| [Wikidata](https://www.wikidata.org/) (place info) | CC0 1.0 | None required |
+| [Wikipedia](https://en.wikipedia.org/) (extracts) | CC BY-SA 3.0 | Wikipedia contributors |
+
+**Bundled software:** [MapLibre GL JS](https://maplibre.org/) (BSD-3-Clause), [Leaflet](https://leafletjs.com/) (BSD-2-Clause)
+
+> **Note on commercial use:** The Sentinel-2 cloudless 2021 satellite imagery
+> is licensed CC BY-NC-SA 4.0, which **restricts commercial use**. ZIM files
+> containing satellite tiles may only be distributed for non-commercial
+> purposes. To distribute commercially, simply omit the `--satellite`
+> flag when building, or substitute imagery with a permissive license.
+> All other data sources permit commercial redistribution with proper
+> attribution.

--- a/create_osm_zim.py
+++ b/create_osm_zim.py
@@ -25,6 +25,7 @@ Size comparison (typical city):
 """
 
 import argparse
+import datetime
 import glob
 import gzip
 import json
@@ -54,7 +55,7 @@ VIEWER_DIR = RESOURCES_DIR / "viewer"
 # Geofabrik base URL for downloading OSM extracts
 GEOFABRIK_BASE = "https://download.geofabrik.de"
 
-# Sentinel-2 Cloudless satellite tile service (EOX, CC BY 4.0 for 2016 vintage)
+# Sentinel-2 Cloudless satellite tile service (EOX, CC BY-NC-SA 4.0 for 2021 vintage)
 SATELLITE_TILE_URL = "https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2021_3857/default/g/{z}/{y}/{x}.jpg"
 
 # Copernicus GLO-30 DEM tile URL (public S3, no auth)
@@ -1621,8 +1622,16 @@ def create_zim(
         creator.add_metadata("Language", "eng")
         creator.add_metadata("Publisher", "create_osm_zim")
         creator.add_metadata("Creator", "OpenStreetMap contributors")
-        creator.add_metadata("Date", "2026-03-10")
+        creator.add_metadata("Date", datetime.date.today().isoformat())
         creator.add_metadata("Tags", "maps;osm;offline")
+        creator.add_metadata("License", (
+            "Map data: ODbL (OpenStreetMap); "
+            "Tile schema: CC-BY 4.0 (OpenMapTiles); "
+            "Satellite imagery: CC BY-NC-SA 4.0 (Sentinel-2 cloudless by EOX); "
+            "Elevation: Copernicus GLO-30 DEM © DLR/Airbus, provided under COPERNICUS by EU and ESA; "
+            "Place info: CC0 (Wikidata) / CC BY-SA 3.0 (Wikipedia); "
+            "Tool code: MIT"
+        ))
 
         # Add the viewer HTML (main page)
         print("    Adding viewer HTML...")

--- a/resources/viewer-leaflet/index.html
+++ b/resources/viewer-leaflet/index.html
@@ -96,7 +96,7 @@
                 maxZoom: 19,
                 tileSize: 512,
                 zoomOffset: -1,
-                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors | <a href="https://openmaptiles.org/">OpenMapTiles</a>',
                 errorTileUrl: ''
             }).addTo(map);
 
@@ -114,7 +114,7 @@
                     maxZoom: 19,
                     tileSize: satTileSize,
                     zoomOffset: satTileSize === 512 ? -1 : 0,
-                    attribution: '&copy; <a href="https://s2maps.eu">Sentinel-2 Cloudless</a> by EOX'
+                    attribution: '&copy; <a href="https://s2maps.eu">Sentinel-2 Cloudless</a> by EOX (Contains modified Copernicus Sentinel data 2021)'
                 });
 
                 var toggleBtn = document.getElementById('layer-toggle');

--- a/resources/viewer/index.html
+++ b/resources/viewer/index.html
@@ -340,7 +340,7 @@
     <section>
       <h3>Terrain / Elevation</h3>
       <p>Copernicus GLO-30 Digital Elevation Model</p>
-      <p class="license">Copernicus Programme, free and open access &mdash; provided by ESA / Airbus</p>
+      <p class="license">&copy; DLR e.V. 2010-2014 and &copy; Airbus Defence and Space GmbH 2014-2018, provided under COPERNICUS by the European Union and ESA; all rights reserved</p>
     </section>
     <section>
       <h3>Place Information</h3>
@@ -658,7 +658,8 @@ function makeStyle(config) {
     "type": "vector",
     "tiles": [tileUrl],
     "minzoom": config.minZoom || 0,
-    "maxzoom": config.maxZoom || 14
+    "maxzoom": config.maxZoom || 14,
+    "attribution": '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors | <a href="https://openmaptiles.org/">OpenMapTiles</a>'
   };
   if (config.bounds) {
     sourceConfig.bounds = config.bounds;


### PR DESCRIPTION
- Create LICENSE file covering MIT tool code + all third-party data sources
- Add attribution text to MapLibre attribution control (OSM + OpenMapTiles)
- Fix Copernicus DEM license to use official required attribution text
- Fix Sentinel-2 code comment: 2021 vintage is CC BY-NC-SA 4.0, not CC BY 4.0
- Add License metadata field to ZIM file creator
- Make ZIM Date metadata dynamic (was hardcoded)
- Update Leaflet viewer attribution (add OpenMapTiles, full Sentinel-2 credit)
- Expand README license section with complete table and commercial use note

https://claude.ai/code/session_011FVZ8edLRb2FZcEDrgBUkX