### PR TITLE
Add offline routing with A* pathfinding for ZIM maps

### DIFF
--- a/create_osm_zim.py
+++ b/create_osm_zim.py
@@ -1267,6 +1267,220 @@ def _assign_location_batch(batch):
     return results
 
 
+def extract_routing_graph(pbf_path, output_dir):
+    """Extract road network from OSM PBF and build a compact routing graph.
+
+    Uses osmium to filter highway ways, then exports as GeoJSONSeq.
+    Builds a graph where intersections (and way endpoints) are nodes,
+    and road segments between them are edges with distance and geometry.
+
+    Returns the path to the output JSON file, or None if extraction fails.
+    """
+    import math
+
+    print("  Extracting routing graph from OSM data...")
+
+    # Step 1: Filter highway ways from PBF
+    highways_pbf = os.path.join(output_dir, "highways.osm.pbf")
+    cmd = [
+        "osmium", "tags-filter", str(pbf_path),
+        "w/highway",
+        "-o", highways_pbf, "--overwrite",
+    ]
+    print(f"    Filtering highway ways...")
+    subprocess.run(cmd, check=True)
+    size_mb = os.path.getsize(highways_pbf) / (1024 * 1024)
+    print(f"    Highway PBF: {size_mb:.1f} MB")
+
+    # Step 2: Export as GeoJSONSeq (newline-delimited GeoJSON)
+    highways_geojson = os.path.join(output_dir, "highways.geojsonseq")
+    cmd = [
+        "osmium", "export", highways_pbf,
+        "-f", "geojsonseq",
+        "-o", highways_geojson, "--overwrite",
+    ]
+    print(f"    Exporting to GeoJSON...")
+    subprocess.run(cmd, check=True)
+
+    # Step 3: Read features and build graph
+    SNAP = 6  # decimal places for coordinate snapping (~0.1m)
+
+    # Highway classes excluded from routing (non-navigable)
+    EXCLUDED = {
+        "proposed", "construction", "raceway", "bus_guideway",
+        "platform", "elevator", "razed", "abandoned",
+    }
+    # Speed estimates (km/h) by highway class for travel time
+    SPEED = {
+        "motorway": 100, "motorway_link": 60,
+        "trunk": 80, "trunk_link": 50,
+        "primary": 60, "primary_link": 40,
+        "secondary": 50, "secondary_link": 35,
+        "tertiary": 40, "tertiary_link": 30,
+        "residential": 30, "living_street": 20,
+        "unclassified": 40, "service": 20,
+        "track": 15, "path": 5, "footway": 5,
+        "cycleway": 15, "pedestrian": 5, "steps": 3,
+    }
+    DEFAULT_SPEED = 30
+
+    coord_count = {}  # snapped (lat, lon) -> count of ways containing it
+    ways = []  # [(coords, highway_class, oneway, speed)]
+
+    print(f"    Reading highway features...")
+    feat_count = 0
+    with open(highways_geojson) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            feat = json.loads(line)
+            geom = feat.get("geometry", {})
+            props = feat.get("properties", {})
+
+            if geom.get("type") != "LineString":
+                continue
+
+            highway = props.get("highway", "")
+            if highway in EXCLUDED or not highway:
+                continue
+
+            # Determine one-way direction
+            ow = props.get("oneway", "")
+            if ow in ("yes", "1", "true"):
+                oneway = 1   # forward only
+            elif ow == "-1":
+                oneway = -1  # reverse only
+            else:
+                oneway = 0   # bidirectional
+
+            speed = SPEED.get(highway, DEFAULT_SPEED)
+
+            coords = []
+            for c in geom["coordinates"]:
+                lat = round(c[1], SNAP)
+                lon = round(c[0], SNAP)
+                coords.append((lat, lon))
+
+            if len(coords) < 2:
+                continue
+
+            ways.append((coords, highway, oneway, speed))
+            feat_count += 1
+
+            for coord in coords:
+                coord_count[coord] = coord_count.get(coord, 0) + 1
+
+            if feat_count % 50000 == 0:
+                print(f"\r    Read {feat_count} features...", end="", flush=True)
+
+    print(f"\r    Read {feat_count} highway features, {len(coord_count)} unique coordinates")
+
+    if feat_count == 0:
+        print("    Warning: no highway features found, skipping routing graph")
+        return None
+
+    # Step 4: Identify graph nodes (intersections + endpoints)
+    graph_nodes = set()
+    for coords, _, _, _ in ways:
+        graph_nodes.add(coords[0])
+        graph_nodes.add(coords[-1])
+        for coord in coords[1:-1]:
+            if coord_count.get(coord, 0) >= 2:
+                graph_nodes.add(coord)
+
+    node_list = sorted(graph_nodes)
+    node_index = {coord: i for i, coord in enumerate(node_list)}
+    print(f"    Graph nodes: {len(node_list)} (intersections + endpoints)")
+
+    # Haversine distance in meters
+    R = 6371000.0
+    def _haversine(lat1, lon1, lat2, lon2):
+        dlat = math.radians(lat2 - lat1)
+        dlon = math.radians(lon2 - lon1)
+        a = (math.sin(dlat / 2) ** 2 +
+             math.cos(math.radians(lat1)) * math.cos(math.radians(lat2)) *
+             math.sin(dlon / 2) ** 2)
+        return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+    # Step 5: Build edges by splitting ways at graph nodes
+    edges = []  # [from_idx, to_idx, dist_m, speed_kmh, [geometry]]
+    for coords, highway, oneway, speed in ways:
+        # Split into segments at graph nodes
+        seg_start = 0
+        for i in range(1, len(coords)):
+            if coords[i] in node_index:
+                seg = coords[seg_start:i + 1]
+                if len(seg) >= 2:
+                    from_idx = node_index[seg[0]]
+                    to_idx = node_index[seg[-1]]
+                    if from_idx != to_idx:
+                        dist = sum(
+                            _haversine(seg[j][0], seg[j][1], seg[j+1][0], seg[j+1][1])
+                            for j in range(len(seg) - 1)
+                        )
+                        dist = round(dist, 1)
+                        # Geometry: intermediate points only (endpoints are the nodes)
+                        geom = [[c[1], c[0]] for c in seg[1:-1]] if len(seg) > 2 else []
+
+                        # Add forward edge
+                        if oneway != -1:
+                            edges.append([from_idx, to_idx, dist, speed, geom])
+                        # Add reverse edge
+                        if oneway != 1:
+                            rev_geom = list(reversed(geom))
+                            edges.append([to_idx, from_idx, dist, speed, rev_geom])
+
+                seg_start = i
+
+    print(f"    Graph edges: {len(edges)}")
+
+    # Step 6: Serialize to compact JSON
+    # Nodes: flat array [lat0, lon0, lat1, lon1, ...]
+    nodes_flat = []
+    for lat, lon in node_list:
+        nodes_flat.append(lat)
+        nodes_flat.append(lon)
+
+    # Build adjacency list for efficient lookup: adj[node] = [[target, dist, speed, geomIdx], ...]
+    # Store geometries separately to allow dedup
+    geom_list = []
+    geom_map = {}  # tuple(geom) -> index
+    adj = [[] for _ in range(len(node_list))]
+
+    for from_idx, to_idx, dist, speed, geom in edges:
+        geom_key = tuple(tuple(c) for c in geom) if geom else ()
+        if geom_key in geom_map:
+            gi = geom_map[geom_key]
+        elif geom:
+            gi = len(geom_list)
+            geom_list.append(geom)
+            geom_map[geom_key] = gi
+        else:
+            gi = -1
+        adj[from_idx].append([to_idx, dist, speed, gi])
+
+    routing_data = {
+        "nodes": nodes_flat,
+        "adj": adj,
+        "geom": geom_list,
+    }
+
+    output_path = os.path.join(output_dir, "routing-graph.json")
+    with open(output_path, "w") as f:
+        json.dump(routing_data, f, separators=(",", ":"))
+
+    size_mb = os.path.getsize(output_path) / (1024 * 1024)
+    print(f"    Routing graph: {size_mb:.1f} MB ({len(node_list)} nodes, {len(edges)} edges)")
+
+    # Clean up temp files
+    for tmp in [highways_pbf, highways_geojson]:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+
+    return output_path
+
+
 def extract_searchable_features(tiles=None, mbtiles_path=None, output_dir=None):
     """Extract named features from z14 vector tiles for search indexing.
 
@@ -1561,6 +1775,7 @@ def create_zim(
     zim_workers=None,
     bbox=None,
     wikidata_data=None,
+    routing_graph_path=None,
 ):
     """Create a ZIM file containing the map viewer and all tiles."""
     from libzim.writer import Creator, Item, StringProvider, FileProvider
@@ -1960,6 +2175,17 @@ def create_zim(
                 for v in wd_chunks.values()
             )
             print(f"    Added {len(wd_chunks)} Wikidata chunks ({total_bytes / 1024:.0f} KB)")
+
+        # Add routing graph data
+        if routing_graph_path and os.path.isfile(routing_graph_path):
+            size_mb = os.path.getsize(routing_graph_path) / (1024 * 1024)
+            print(f"    Adding routing graph ({size_mb:.1f} MB)...")
+            creator.add_item(MapItem(
+                "routing-data/graph.json",
+                "Routing Graph",
+                "application/json",
+                routing_graph_path,
+            ))
 
         # Build location index for search feature enrichment
         loc_lookup = None
@@ -2387,6 +2613,8 @@ Known areas: """ + ", ".join(sorted(KNOWN_AREAS.keys())),
     parser.add_argument("--search-cache", metavar="PATH", default=None,
                         help="Use pre-built search features JSONL instead of extracting from tiles. "
                              "If bbox is set, features are filtered to the bounding box.")
+    parser.add_argument("--routing", action="store_true",
+                        help="Include offline routing graph for turn-by-turn directions")
 
     args = parser.parse_args()
 
@@ -2439,7 +2667,10 @@ Known areas: """ + ", ".join(sorted(KNOWN_AREAS.keys())),
     include_wikidata = args.wikidata
     wikidata_cache_dir = args.wikidata_cache
 
-    total_steps = 6 + (1 if include_satellite else 0) + (1 if include_terrain else 0) + (1 if include_wikidata else 0)
+    # Routing options
+    include_routing = args.routing
+
+    total_steps = 6 + (1 if include_satellite else 0) + (1 if include_terrain else 0) + (1 if include_wikidata else 0) + (1 if include_routing else 0)
 
     print(f"=== Creating Offline OSM ZIM: {name} ===")
     if include_satellite:
@@ -2449,6 +2680,8 @@ Known areas: """ + ", ".join(sorted(KNOWN_AREAS.keys())),
         print(f"  Including Copernicus GLO-30 terrain (z0-{terrain_max_zoom})")
     if include_wikidata:
         print(f"  Including Wikidata info for places and POIs")
+    if include_routing:
+        print(f"  Including offline routing graph")
     print()
 
     # Create temp directory
@@ -2574,6 +2807,19 @@ Known areas: """ + ", ".join(sorted(KNOWN_AREAS.keys())),
                 print(f"    Loaded {len(wikidata_data)} Wikidata entries for ZIM")
             else:
                 print("    No Wikidata entries available")
+
+        # Extract routing graph if requested
+        routing_graph_path = None
+        if include_routing:
+            step_rt = 5 + (1 if include_wikidata else 0)
+            print()
+            print(f"[{step_rt}/{total_steps}] Extracting routing graph...")
+            rt_pbf = locals().get('work_pbf') or pbf_path or args.pbf
+            if not rt_pbf:
+                print("    Warning: no PBF file available, skipping routing graph")
+                print("    (routing requires a PBF file — not available with --mbtiles only)")
+            else:
+                routing_graph_path = extract_routing_graph(rt_pbf, tmpdir)
 
         # Download satellite tiles and generate terrain tiles
         # These are independent (satellite=I/O-bound, terrain=CPU-bound) so run in parallel
@@ -2728,6 +2974,8 @@ Known areas: """ + ", ".join(sorted(KNOWN_AREAS.keys())),
             map_config["terrainMaxZoom"] = terrain_max_zoom
         if wikidata_data:
             map_config["hasWikidata"] = True
+        if routing_graph_path:
+            map_config["hasRouting"] = True
 
         create_zim(
             output_path=output_path,
@@ -2753,6 +3001,7 @@ Known areas: """ + ", ".join(sorted(KNOWN_AREAS.keys())),
             tile_count=total_tile_count if use_streaming else None,
             bbox=parse_bbox(bbox_str) if bbox_str else None,
             wikidata_data=wikidata_data,
+            routing_graph_path=routing_graph_path,
         )
 
         print()

--- a/resources/viewer/index.html
+++ b/resources/viewer/index.html
@@ -287,6 +287,75 @@
   .wiki-empty-state-text {
     font-size: 13px; color: var(--text-tertiary); line-height: 1.5;
   }
+
+  /* --- Routing --- */
+  #routing-panel {
+    display: none; position: absolute; top: 10px; left: 10px; z-index: 3;
+    width: 280px; max-width: calc(100% - 80px);
+    background: var(--panel-bg); border-radius: var(--radius);
+    box-shadow: var(--panel-shadow);
+    backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
+    font-family: var(--ui-font); font-size: 13px;
+    padding: 12px 14px;
+  }
+  #routing-panel h4 {
+    margin: 0 0 10px; font-size: 13px; font-weight: 600;
+    color: var(--text-primary); display: flex; justify-content: space-between; align-items: center;
+  }
+  #routing-panel h4 button {
+    background: none; border: none; font-size: 18px; cursor: pointer;
+    color: var(--text-tertiary); padding: 0 2px; line-height: 1;
+  }
+  #routing-panel h4 button:hover { color: var(--text-primary); }
+  .routing-field {
+    display: flex; align-items: center; gap: 8px; margin-bottom: 8px;
+  }
+  .routing-dot {
+    width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0;
+  }
+  .routing-dot.origin { background: #22c55e; }
+  .routing-dot.dest { background: #ef4444; }
+  .routing-field span {
+    color: var(--text-secondary); font-size: 12px; flex: 1;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .routing-field span.set { color: var(--text-primary); font-weight: 500; }
+  #routing-result {
+    display: none; margin-top: 10px; padding-top: 10px;
+    border-top: 1px solid var(--border);
+  }
+  #routing-result .route-stat {
+    display: flex; justify-content: space-between; margin-bottom: 4px;
+  }
+  #routing-result .route-stat label {
+    color: var(--text-secondary); font-size: 11px;
+  }
+  #routing-result .route-stat value {
+    color: var(--text-primary); font-weight: 600; font-size: 13px;
+  }
+  #routing-clear {
+    display: none; margin-top: 8px; width: 100%;
+    padding: 6px; border: 1px solid var(--border); border-radius: 6px;
+    background: transparent; cursor: pointer; font-family: var(--ui-font);
+    font-size: 12px; color: var(--text-secondary);
+  }
+  #routing-clear:hover { background: var(--hover-bg); color: var(--text-primary); }
+  #routing-status {
+    color: var(--text-tertiary); font-size: 11px; margin-top: 6px;
+  }
+  .routing-marker {
+    width: 24px; height: 24px; cursor: pointer;
+  }
+  .routing-marker-origin {
+    width: 16px; height: 16px; border-radius: 50%;
+    background: #22c55e; border: 3px solid #fff;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.3);
+  }
+  .routing-marker-dest {
+    width: 16px; height: 16px; border-radius: 50%;
+    background: #ef4444; border: 3px solid #fff;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.3);
+  }
 </style>
 </head>
 <body>
@@ -295,6 +364,24 @@
   <button id="layer-toggle" title="Toggle satellite imagery">Satellite</button>
   <button id="terrain-toggle" title="Toggle 3D terrain">3D</button>
   <button id="wiki-toggle" title="Show nearby Wikipedia entries">Explore</button>
+  <button id="route-toggle" title="Get directions between two points">Route</button>
+</div>
+<div id="routing-panel">
+  <h4>Directions <button id="routing-close" title="Close">&times;</button></h4>
+  <div class="routing-field">
+    <div class="routing-dot origin"></div>
+    <span id="routing-origin">Click map to set start</span>
+  </div>
+  <div class="routing-field">
+    <div class="routing-dot dest"></div>
+    <span id="routing-dest">Then click to set destination</span>
+  </div>
+  <div id="routing-status"></div>
+  <div id="routing-result">
+    <div class="route-stat"><label>Distance</label><value id="route-distance"></value></div>
+    <div class="route-stat"><label>Est. time</label><value id="route-time"></value></div>
+  </div>
+  <button id="routing-clear">Clear route</button>
 </div>
 <div id="wiki-panel">
   <div id="wiki-panel-header">
@@ -770,6 +857,9 @@ fetchConfig(1)
 
     // Initialize Wiki sidebar
     initWikiSidebar(map, config);
+
+    // Initialize routing
+    initRouting(map, config);
   })
   .catch(function(err) {
     dbg('fatal error loading map', describeError(err), err && err.stack);
@@ -2000,6 +2090,406 @@ function initWikiSidebar(map, config) {
     }
     clearTimeout(debounceTimer);
     debounceTimer = setTimeout(updateSidebar, 400);
+  });
+}
+
+// --- Routing with A* pathfinding ---
+function initRouting(map, config) {
+  if (!config.hasRouting) return;
+
+  var toggleBtn = document.getElementById('route-toggle');
+  var panel = document.getElementById('routing-panel');
+  var closeBtn = document.getElementById('routing-close');
+  var originLabel = document.getElementById('routing-origin');
+  var destLabel = document.getElementById('routing-dest');
+  var statusEl = document.getElementById('routing-status');
+  var resultEl = document.getElementById('routing-result');
+  var distEl = document.getElementById('route-distance');
+  var timeEl = document.getElementById('route-time');
+  var clearBtn = document.getElementById('routing-clear');
+
+  toggleBtn.style.display = 'block';
+
+  var active = false;
+  var graph = null;       // {nodes: Float64Array, adj: Array, geom: Array}
+  var originNode = -1;
+  var destNode = -1;
+  var originMarker = null;
+  var destMarker = null;
+  var routeDrawn = false;
+
+  // Toggle routing mode
+  toggleBtn.addEventListener('click', function() {
+    active = !active;
+    if (active) {
+      toggleBtn.classList.add('active-control');
+      panel.style.display = 'block';
+      map.getCanvas().style.cursor = 'crosshair';
+      loadGraph();
+    } else {
+      deactivate();
+    }
+  });
+
+  closeBtn.addEventListener('click', deactivate);
+
+  function deactivate() {
+    active = false;
+    toggleBtn.classList.remove('active-control');
+    panel.style.display = 'none';
+    map.getCanvas().style.cursor = '';
+    clearRoute();
+  }
+
+  clearBtn.addEventListener('click', function() {
+    clearRoute();
+    statusEl.textContent = '';
+  });
+
+  function clearRoute() {
+    originNode = -1;
+    destNode = -1;
+    originLabel.textContent = 'Click map to set start';
+    originLabel.classList.remove('set');
+    destLabel.textContent = 'Then click to set destination';
+    destLabel.classList.remove('set');
+    resultEl.style.display = 'none';
+    clearBtn.style.display = 'none';
+    if (originMarker) { originMarker.remove(); originMarker = null; }
+    if (destMarker) { destMarker.remove(); destMarker = null; }
+    if (routeDrawn) {
+      if (map.getLayer('route-line')) map.removeLayer('route-line');
+      if (map.getLayer('route-outline')) map.removeLayer('route-outline');
+      if (map.getSource('route')) map.removeSource('route');
+      routeDrawn = false;
+    }
+  }
+
+  // Load routing graph (lazy)
+  function loadGraph() {
+    if (graph) return;
+    statusEl.textContent = 'Loading routing data...';
+    fetch(baseUrl + 'routing-data/graph.json')
+      .then(function(r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+      })
+      .then(function(data) {
+        graph = data;
+        statusEl.textContent = 'Click map to set start point';
+      })
+      .catch(function(err) {
+        statusEl.textContent = 'Routing data unavailable';
+        console.error('Failed to load routing graph:', err);
+      });
+  }
+
+  // Find nearest graph node to a lat/lon
+  function nearestNode(lat, lon) {
+    var nodes = graph.nodes;
+    var best = -1;
+    var bestDist = Infinity;
+    for (var i = 0; i < nodes.length; i += 2) {
+      var dlat = nodes[i] - lat;
+      var dlon = nodes[i + 1] - lon;
+      var d = dlat * dlat + dlon * dlon;
+      if (d < bestDist) {
+        bestDist = d;
+        best = i / 2;
+      }
+    }
+    return best;
+  }
+
+  // Haversine distance in meters
+  function haversine(lat1, lon1, lat2, lon2) {
+    var R = 6371000;
+    var dLat = (lat2 - lat1) * Math.PI / 180;
+    var dLon = (lon2 - lon1) * Math.PI / 180;
+    var a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+            Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
+            Math.sin(dLon / 2) * Math.sin(dLon / 2);
+    return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  }
+
+  // Binary min-heap for A* priority queue
+  function MinHeap() {
+    this.data = [];
+  }
+  MinHeap.prototype.push = function(item) {
+    this.data.push(item);
+    var i = this.data.length - 1;
+    while (i > 0) {
+      var p = (i - 1) >> 1;
+      if (this.data[p][0] <= this.data[i][0]) break;
+      var tmp = this.data[p];
+      this.data[p] = this.data[i];
+      this.data[i] = tmp;
+      i = p;
+    }
+  };
+  MinHeap.prototype.pop = function() {
+    var top = this.data[0];
+    var last = this.data.pop();
+    if (this.data.length > 0) {
+      this.data[0] = last;
+      var i = 0;
+      while (true) {
+        var l = 2 * i + 1, r = 2 * i + 2, smallest = i;
+        if (l < this.data.length && this.data[l][0] < this.data[smallest][0]) smallest = l;
+        if (r < this.data.length && this.data[r][0] < this.data[smallest][0]) smallest = r;
+        if (smallest === i) break;
+        var tmp = this.data[i];
+        this.data[i] = this.data[smallest];
+        this.data[smallest] = tmp;
+        i = smallest;
+      }
+    }
+    return top;
+  };
+  MinHeap.prototype.size = function() { return this.data.length; };
+
+  // A* pathfinding
+  function findRoute(startNode, endNode) {
+    var nodes = graph.nodes;
+    var adj = graph.adj;
+    var numNodes = nodes.length / 2;
+
+    var endLat = nodes[endNode * 2];
+    var endLon = nodes[endNode * 2 + 1];
+
+    // g[node] = best known cost to reach node (in seconds)
+    var g = new Float64Array(numNodes);
+    g.fill(Infinity);
+    g[startNode] = 0;
+
+    // Track predecessors for path reconstruction
+    var prev = new Int32Array(numNodes);
+    prev.fill(-1);
+    var prevEdge = new Int32Array(numNodes);  // which edge index in adj[prev[n]] leads to n
+    prevEdge.fill(-1);
+
+    var closed = new Uint8Array(numNodes);
+
+    var open = new MinHeap();
+    var h0 = haversine(nodes[startNode * 2], nodes[startNode * 2 + 1], endLat, endLon) / (100 / 3.6);
+    open.push([h0, startNode]);
+
+    while (open.size() > 0) {
+      var item = open.pop();
+      var current = item[1];
+
+      if (current === endNode) break;
+      if (closed[current]) continue;
+      closed[current] = 1;
+
+      var neighbors = adj[current];
+      if (!neighbors) continue;
+
+      for (var i = 0; i < neighbors.length; i++) {
+        var edge = neighbors[i];
+        var target = edge[0];
+        var dist = edge[1];    // meters
+        var speed = edge[2];   // km/h
+
+        if (closed[target]) continue;
+
+        var cost = dist / (speed / 3.6);  // time in seconds
+        var newG = g[current] + cost;
+
+        if (newG < g[target]) {
+          g[target] = newG;
+          prev[target] = current;
+          prevEdge[target] = i;
+          var tLat = nodes[target * 2];
+          var tLon = nodes[target * 2 + 1];
+          var h = haversine(tLat, tLon, endLat, endLon) / (100 / 3.6);
+          open.push([newG + h, target]);
+        }
+      }
+    }
+
+    if (g[endNode] === Infinity) return null;
+
+    // Reconstruct path
+    var path = [];
+    var totalDist = 0;
+    var totalTime = g[endNode];
+    var n = endNode;
+
+    while (n !== startNode) {
+      var p = prev[n];
+      var ei = prevEdge[n];
+      var edge = adj[p][ei];
+      totalDist += edge[1];
+
+      // Build segment geometry
+      var fromLat = nodes[p * 2], fromLon = nodes[p * 2 + 1];
+      var toLat = nodes[n * 2], toLon = nodes[n * 2 + 1];
+      var geomIdx = edge[3];
+      var segment = [[fromLon, fromLat]];
+      if (geomIdx >= 0 && graph.geom[geomIdx]) {
+        var pts = graph.geom[geomIdx];
+        for (var j = 0; j < pts.length; j++) {
+          segment.push(pts[j]);
+        }
+      }
+      segment.push([toLon, toLat]);
+      path.unshift(segment);
+
+      n = p;
+    }
+
+    // Flatten path segments into single coordinate array
+    var coords = [];
+    for (var s = 0; s < path.length; s++) {
+      var start = (s === 0) ? 0 : 1;  // skip duplicate junction points
+      for (var k = start; k < path[s].length; k++) {
+        coords.push(path[s][k]);
+      }
+    }
+
+    return {
+      coords: coords,
+      distance: totalDist,
+      time: totalTime
+    };
+  }
+
+  function drawRoute(coords) {
+    if (routeDrawn) {
+      map.getSource('route').setData({
+        type: 'Feature',
+        geometry: { type: 'LineString', coordinates: coords }
+      });
+    } else {
+      map.addSource('route', {
+        type: 'geojson',
+        data: {
+          type: 'Feature',
+          geometry: { type: 'LineString', coordinates: coords }
+        }
+      });
+      map.addLayer({
+        id: 'route-outline',
+        type: 'line',
+        source: 'route',
+        paint: {
+          'line-color': '#1e40af',
+          'line-width': 8,
+          'line-opacity': 0.4
+        }
+      });
+      map.addLayer({
+        id: 'route-line',
+        type: 'line',
+        source: 'route',
+        paint: {
+          'line-color': '#2563eb',
+          'line-width': 4,
+          'line-opacity': 0.9
+        }
+      });
+      routeDrawn = true;
+    }
+  }
+
+  function formatDistance(meters) {
+    if (meters < 1000) return Math.round(meters) + ' m';
+    return (meters / 1000).toFixed(1) + ' km';
+  }
+
+  function formatTime(seconds) {
+    if (seconds < 60) return Math.round(seconds) + ' sec';
+    var mins = Math.round(seconds / 60);
+    if (mins < 60) return mins + ' min';
+    var hrs = Math.floor(mins / 60);
+    var rem = mins % 60;
+    return hrs + ' hr ' + rem + ' min';
+  }
+
+  function coordLabel(lat, lon) {
+    return lat.toFixed(4) + ', ' + lon.toFixed(4);
+  }
+
+  function makeMarkerEl(cls) {
+    var el = document.createElement('div');
+    el.className = 'routing-marker';
+    var inner = document.createElement('div');
+    inner.className = cls;
+    el.appendChild(inner);
+    return el;
+  }
+
+  // Map click handler for routing
+  map.on('click', function(e) {
+    if (!active || !graph) return;
+
+    var lat = e.lngLat.lat;
+    var lon = e.lngLat.lng;
+
+    if (originNode === -1) {
+      // Set origin
+      originNode = nearestNode(lat, lon);
+      var oLat = graph.nodes[originNode * 2];
+      var oLon = graph.nodes[originNode * 2 + 1];
+      originLabel.textContent = coordLabel(oLat, oLon);
+      originLabel.classList.add('set');
+      statusEl.textContent = 'Click map to set destination';
+
+      if (originMarker) originMarker.remove();
+      originMarker = new maplibregl.Marker({ element: makeMarkerEl('routing-marker-origin'), anchor: 'center' })
+        .setLngLat([oLon, oLat])
+        .addTo(map);
+    } else if (destNode === -1) {
+      // Set destination
+      destNode = nearestNode(lat, lon);
+      var dLat = graph.nodes[destNode * 2];
+      var dLon = graph.nodes[destNode * 2 + 1];
+      destLabel.textContent = coordLabel(dLat, dLon);
+      destLabel.classList.add('set');
+      statusEl.textContent = 'Calculating route...';
+
+      if (destMarker) destMarker.remove();
+      destMarker = new maplibregl.Marker({ element: makeMarkerEl('routing-marker-dest'), anchor: 'center' })
+        .setLngLat([dLon, dLat])
+        .addTo(map);
+
+      // Calculate route
+      setTimeout(function() {
+        var result = findRoute(originNode, destNode);
+        if (result) {
+          drawRoute(result.coords);
+          distEl.textContent = formatDistance(result.distance);
+          timeEl.textContent = formatTime(result.time);
+          resultEl.style.display = 'block';
+          clearBtn.style.display = 'block';
+          statusEl.textContent = '';
+
+          // Fit map to route
+          var bounds = result.coords.reduce(function(b, c) {
+            return b.extend(c);
+          }, new maplibregl.LngLatBounds(result.coords[0], result.coords[0]));
+          map.fitBounds(bounds, { padding: 60, duration: 1000 });
+        } else {
+          statusEl.textContent = 'No route found';
+          clearBtn.style.display = 'block';
+        }
+      }, 10);
+    } else {
+      // Reset and set new origin
+      clearRoute();
+      originNode = nearestNode(lat, lon);
+      var nLat = graph.nodes[originNode * 2];
+      var nLon = graph.nodes[originNode * 2 + 1];
+      originLabel.textContent = coordLabel(nLat, nLon);
+      originLabel.classList.add('set');
+      statusEl.textContent = 'Click map to set destination';
+
+      originMarker = new maplibregl.Marker({ element: makeMarkerEl('routing-marker-origin'), anchor: 'center' })
+        .setLngLat([nLon, nLat])
+        .addTo(map);
+    }
   });
 }
 </script>


### PR DESCRIPTION
Extract road network from OSM PBF at build time using osmium, build a
compact routing graph (nodes at intersections, edges with distance/speed
and geometry), and embed it in the ZIM file. The viewer implements A*
shortest-path search with a binary min-heap priority queue, snaps
clicks to the nearest graph node, and draws the route on the map with
distance and estimated travel time.

Build: python3 create_osm_zim.py --area dc --routing
Viewer: click Route button, click origin, click destination.

https://claude.ai/code/session_013pW7uUTnyxPmHtPJQtqDUp