### PR TITLE
Drive/Walk/Bike modes + Firebase PWA that reads a local ZIM offline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ terrain_cache*/
 terrain_compression_test/
 world-data/
 wikidata_cache/
+
+# PWA assets populated by scripts/sync-drive-viewer.sh (run via Firebase
+# predeploy hook). Keeping them out of git avoids drift with the
+# canonical viewer in resources/viewer/ and the CDN-hosted libraries.
+web/drive/viewer/
+web/drive/fzstd.js

--- a/create_osm_zim.py
+++ b/create_osm_zim.py
@@ -75,7 +75,7 @@ COPERNICUS_DEM_URL_GLO90 = (
 )
 
 # MapLibre GL JS version to bundle
-MAPLIBRE_VERSION = "5.20.0"
+MAPLIBRE_VERSION = "5.23.0"
 MAPLIBRE_CDN = f"https://unpkg.com/maplibre-gl@{MAPLIBRE_VERSION}/dist"
 
 

--- a/docs/driving-mode-road-class-warnings.md
+++ b/docs/driving-mode-road-class-warnings.md
@@ -1,0 +1,239 @@
+# Road-class warnings for Walk / Bike driving mode
+
+Design notes for the deferred feature: flag the user when they enter
+Walk or Bike mode on a planned route that includes roads unsuitable for
+that travel mode (e.g. an Interstate motorway).
+
+Status: **not implemented**. This doc captures what would need to change
+so it can be picked up later without re-deriving the plan.
+
+---
+
+## Why
+
+The router in `create_osm_zim.py` uses a single graph with car speeds.
+When a user asks for a route and hits **Walk** or **Bike**, the follow-
+mode will happily lead them along a motorway / trunk road. That's at
+minimum unpleasant and in many jurisdictions illegal (interstates in the
+US, Autobahns in DE). We want a friendly up-front warning:
+
+> *"This route uses motorway segments — not safe for walking."*
+
+A full fix (separate walk/bike routing profiles) is out of scope; this
+note covers only the **warning** pass, which is small and additive.
+
+---
+
+## Current state of the routing graph
+
+Baked by `create_osm_zim.py::build_routing_graph` (around line 1720+),
+written as **SZRG v3** (`resources/viewer/index.html::initRouting`
+parses it around line ~2370+). Per-edge record:
+
+```
+struct EdgeV3 {
+    uint32_t target;        // destination node index
+    uint32_t dist_speed;    // (speed_kmh << 24) | dist_dm_24bit
+    uint32_t geom_idx;      // 0xFFFFFFFF = no geometry
+    uint32_t name_idx;      // index into name blob
+};                          // 16 bytes
+```
+
+There is **no road-class field**. The baker knows the class at edge
+construction time (`SPEED` dict keyed on the OSM `highway=*` tag, line
+~1751), but throws it away after resolving the speed.
+
+---
+
+## Proposed format — SZRG v4
+
+Add one u32 per edge:
+
+```
+struct EdgeV4 {
+    uint32_t target;
+    uint32_t dist_speed;    // unchanged
+    uint32_t geom_idx;      // unchanged
+    uint32_t name_idx;      // unchanged
+    uint32_t class_access;  // NEW
+};                          // 20 bytes
+```
+
+Bit layout of `class_access` (little-endian u32):
+
+| bits   | meaning                                                    |
+|--------|------------------------------------------------------------|
+| 0..4   | road class ordinal (see table below) — 5 bits, 32 values   |
+| 5..7   | access flags (bit 5=no-foot, bit 6=no-bicycle, bit 7=oneway) |
+| 8..31  | reserved — zero-fill, room for future use                  |
+
+Road-class ordinals (same 16 classes the speed table uses, packed):
+
+| ord | class          | car ok | foot ok | bicycle ok |
+|-----|----------------|:------:|:-------:|:----------:|
+|  0  | unknown        |   ✓    |    ✓    |     ✓      |
+|  1  | motorway       |   ✓    |    ✗    |     ✗      |
+|  2  | motorway_link  |   ✓    |    ✗    |     ✗      |
+|  3  | trunk          |   ✓    |    ⚠    |     ⚠      |
+|  4  | trunk_link     |   ✓    |    ⚠    |     ⚠      |
+|  5  | primary        |   ✓    |    ✓    |     ✓      |
+|  6  | primary_link   |   ✓    |    ✓    |     ✓      |
+|  7  | secondary      |   ✓    |    ✓    |     ✓      |
+|  8  | secondary_link |   ✓    |    ✓    |     ✓      |
+|  9  | tertiary       |   ✓    |    ✓    |     ✓      |
+| 10  | tertiary_link  |   ✓    |    ✓    |     ✓      |
+| 11  | residential    |   ✓    |    ✓    |     ✓      |
+| 12  | living_street  |   ✓    |    ✓    |     ✓      |
+| 13  | unclassified   |   ✓    |    ✓    |     ✓      |
+| 14  | service        |   ✓    |    ✓    |     ✓      |
+| 15  | track          |   ✓    |    ✓    |     ✓      |
+| 16  | path           |   ✗    |    ✓    |     ✓      |
+| 17  | footway        |   ✗    |    ✓    |     ⚠      |
+| 18  | cycleway       |   ✗    |    ✓    |     ✓      |
+| 19  | pedestrian     |   ✗    |    ✓    |     ⚠      |
+| 20  | steps          |   ✗    |    ✓    |     ✗      |
+| 21..31 | reserved    |        |         |            |
+
+Legend: ✓ allowed, ✗ forbidden, ⚠ allowed but discouraged / warn.
+
+The access bits (5..7) are explicit overrides derived from OSM tags
+(`foot=no`, `bicycle=no`, `oneway=yes`) and take precedence over the
+class defaults when set.
+
+---
+
+## Baker changes (`create_osm_zim.py`)
+
+Near the existing `SPEED` dict at line ~1751, add a parallel
+`CLASS_ORDINAL = {"motorway": 1, "motorway_link": 2, ...}` lookup.
+
+In the edge-building pass that currently computes `speed` and appends to
+`edges_dist_speed` (lines ~2040–2060), also:
+
+```python
+class_ord = CLASS_ORDINAL.get(highway_tag, 0)
+access = 0
+if tags.get("foot") == "no":     access |= 0x20  # bit 5
+if tags.get("bicycle") == "no":  access |= 0x40  # bit 6
+if tags.get("oneway") == "yes":  access |= 0x80  # bit 7
+edges_class_access.append(class_ord | access)
+```
+
+Serialize a new column after `name_idx` in the edges array, and bump
+the version byte in the header write (line ~2131) from `3` to `4`.
+
+The per-edge overhead is **4 bytes × numEdges**. For a US-wide graph
+with ~50M edges that's ~200 MB — meaningful but not blocking. If the
+size matters, an alternative is to pack the 5-bit class into the top
+bits of `name_idx` (which rarely exceeds 2^24 distinct names) and keep
+the record at 16 bytes; this doc picks the simpler u32 column for
+clarity.
+
+---
+
+## Viewer reader changes (`resources/viewer/index.html::initRouting`)
+
+The binary parser at ~line 2370 already branches on the version byte.
+Add a v4 branch:
+
+```js
+if (version === 4) {
+  // Same as v3 but edges are 5 u32 per record instead of 4.
+  edgeStride = 5;
+  hasClassAccess = true;
+}
+```
+
+Add an accessor:
+
+```js
+function edgeClassOrdinal(i) {
+  return edges[i * edgeStride + 4] & 0x1F;
+}
+function edgeAccessFlags(i) {
+  return (edges[i * edgeStride + 4] >> 5) & 0x07;
+}
+```
+
+In `findRoute` (line ~2620), inside the reconstruction loop that walks
+`prevEdge[n]`, collect per-edge class ordinals alongside the existing
+`segRev`:
+
+```js
+segRev.push({ nameIdx, distM, classOrd: edgeClassOrdinal(ei),
+              access: edgeAccessFlags(ei) });
+```
+
+Then emit a `classes` summary on the returned route object:
+
+```js
+return {
+  coords, distance, time, roads,
+  classes: summarizeClasses(segRev)
+};
+
+// returns { totalByClass: { 1: 4500, 5: 800, ... }, worst: 1, hasForbidden: {foot: true, bicycle: true} }
+```
+
+---
+
+## Driving-mode UI changes (`resources/viewer/index.html`)
+
+At the top of `driveMode.enter(mode)` (around line ~3410), after
+resolving the mode preset, check the route's class summary:
+
+```js
+var warn = checkRouteForMode(lastRoute, state.mode);
+if (warn) {
+  setStatus(warn);      // yellow banner already in the HUD
+}
+```
+
+Where `checkRouteForMode` returns a human string or null:
+
+```js
+function checkRouteForMode(route, mode) {
+  if (!route.classes) return null;
+  if (mode === 'walk' && route.classes.hasForbidden.foot) {
+    return 'This route uses motorway / link roads — unsafe for walking.';
+  }
+  if (mode === 'bike' && route.classes.hasForbidden.bicycle) {
+    return 'This route uses motorway / link roads — unsafe for biking.';
+  }
+  return null;
+}
+```
+
+Optional niceties (small, additive):
+
+- Also surface the warning on the routing panel at route-compute time,
+  so the user sees it before they commit to a mode.
+- Add a "Suggest an alternative" button that reruns `findRoute` with a
+  higher cost multiplier on forbidden classes for the active mode. This
+  is real work (A* weight overrides) but stays inside the viewer.
+
+---
+
+## Migration
+
+Old ZIMs ship SZRG v3 → new viewer must keep reading v3 (no class info,
+warnings silently skipped — acceptable fallback). The version byte in
+the header already gates this cleanly.
+
+New ZIMs ship v4 → old viewers (SZRG v3-only) will refuse to load the
+graph. Acceptable since routing is gated behind a feature check in the
+viewer config anyway. If we want graceful degradation on mixed versions,
+add a v3-compatible writer mode behind a `--routing-graph-version` CLI
+flag in `create_osm_zim.py`.
+
+---
+
+## Scope estimate
+
+- Baker change: ~40 lines (dict + one column + version bump)
+- Reader change: ~30 lines (v4 branch + two accessors + classes summary)
+- UI warning:    ~20 lines (banner string + mode check)
+- Tests:         regenerate a small-region ZIM, verify warnings fire for
+                 a known motorway-traversing route
+
+Rebuild cost: one ZIM per region (same as any graph change).

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,9 @@
 {
   "hosting": {
     "public": "web",
+    "predeploy": [
+      "bash scripts/sync-drive-viewer.sh"
+    ],
     "ignore": [
       "firebase.json",
       "**/.*",
@@ -31,6 +34,26 @@
         "headers": [
           { "key": "Content-Type", "value": "application/manifest+json" },
           { "key": "Cache-Control", "value": "public, max-age=300" }
+        ]
+      },
+      {
+        "source": "drive/zim-reader.js",
+        "headers": [
+          { "key": "Content-Type", "value": "text/javascript" },
+          { "key": "Cache-Control", "value": "public, max-age=3600" }
+        ]
+      },
+      {
+        "source": "drive/fzstd.js",
+        "headers": [
+          { "key": "Content-Type", "value": "text/javascript" },
+          { "key": "Cache-Control", "value": "public, max-age=86400" }
+        ]
+      },
+      {
+        "source": "drive/viewer/maplibre-gl.@(js|css)",
+        "headers": [
+          { "key": "Cache-Control", "value": "public, max-age=86400" }
         ]
       }
     ],

--- a/resources/viewer/index.html
+++ b/resources/viewer/index.html
@@ -401,15 +401,21 @@
     font-size: 12px; color: var(--text-secondary);
   }
   #routing-clear:hover { background: var(--hover-bg); color: var(--text-primary); }
-  #routing-drive {
-    display: none; margin-top: 8px; width: 100%;
-    padding: 8px; border: none; border-radius: 6px;
+  #routing-go-row {
+    display: none; margin-top: 8px; gap: 6px;
+  }
+  #routing-go-row.visible { display: flex; }
+  #routing-go-row button {
+    flex: 1; padding: 8px 6px; border: none; border-radius: 6px;
     background: #2563eb; cursor: pointer; font-family: var(--ui-font);
     font-size: 13px; font-weight: 600; color: #fff;
-    letter-spacing: 0.3px;
+    letter-spacing: 0.3px; min-width: 0;
   }
-  #routing-drive:hover { background: #1d4ed8; }
-  #routing-drive:active { background: #1e40af; }
+  #routing-go-row button:hover { background: #1d4ed8; }
+  #routing-go-row button:active { background: #1e40af; }
+  #routing-go-row button.active-mode { background: #b91c1c; }
+  #routing-go-row button.active-mode:hover { background: #991b1b; }
+  #routing-go-row button.hidden-mode { display: none; }
   /* --- Driving mode HUD --- */
   #drive-hud {
     display: none; position: absolute; top: 10px; left: 10px; right: 10px;
@@ -513,7 +519,11 @@
     <div class="route-stat"><label>Est. time</label><value id="route-time"></value></div>
     <div id="route-roads"></div>
   </div>
-  <button id="routing-drive">Drive &#9654;</button>
+  <div id="routing-go-row">
+    <button id="routing-drive" data-mode="drive">Drive</button>
+    <button id="routing-walk"  data-mode="walk">Walk</button>
+    <button id="routing-bike"  data-mode="bike">Bike</button>
+  </div>
   <button id="routing-clear">Clear route</button>
 </div>
 <div id="drive-hud" aria-hidden="true">
@@ -2312,7 +2322,28 @@ function initRouting(map, config) {
   var timeEl = document.getElementById('route-time');
   var roadsEl = document.getElementById('route-roads');
   var clearBtn = document.getElementById('routing-clear');
-  var driveBtn = document.getElementById('routing-drive');
+  var goRow = document.getElementById('routing-go-row');
+  var modeBtns = {
+    drive: document.getElementById('routing-drive'),
+    walk:  document.getElementById('routing-walk'),
+    bike:  document.getElementById('routing-bike')
+  };
+  var MODE_LABELS = { drive: 'Drive', walk: 'Walk', bike: 'Bike' };
+  // Per-mode presets — camera feels right for the modality and the avg
+  // speed is used to re-estimate remaining-time since the routing graph
+  // is driver-speeds only. Speeds in m/s: walk≈3.1 mph, bike≈10 mph.
+  var MODE_PRESETS = {
+    drive: { pitch: 60, zoom: 17,   speed: null },  // null = use route's car-speed
+    walk:  { pitch: 45, zoom: 18,   speed: 1.4 },
+    bike:  { pitch: 55, zoom: 17.5, speed: 4.5 }
+  };
+
+  function resetGoButtons() {
+    Object.keys(modeBtns).forEach(function(m) {
+      modeBtns[m].classList.remove('active-mode', 'hidden-mode');
+      modeBtns[m].textContent = MODE_LABELS[m];
+    });
+  }
 
   toggleBtn.style.display = 'block';
 
@@ -2362,8 +2393,8 @@ function initRouting(map, config) {
     destResultsEl.style.display = 'none';
     resultEl.style.display = 'none';
     clearBtn.style.display = 'none';
-    driveBtn.style.display = 'none';
-    driveBtn.innerHTML = 'Drive &#9654;';
+    goRow.classList.remove('visible');
+    resetGoButtons();
     if (driveMode.active) driveMode.exit();
     lastRoute = null;
     if (originMarker) { originMarker.remove(); originMarker = null; }
@@ -2893,7 +2924,8 @@ function initRouting(map, config) {
         renderRoads(result.roads);
         resultEl.style.display = 'block';
         clearBtn.style.display = 'block';
-        driveBtn.style.display = 'block';
+        goRow.classList.add('visible');
+        resetGoButtons();
         lastRoute = augmentRouteForDriving(result);
         if (driveMode.active) driveMode.setRoute(lastRoute);
         statusEl.textContent = '';
@@ -3211,6 +3243,7 @@ function initRouting(map, config) {
 
     var state = {
       active: false,
+      mode: 'drive',
       route: null,
       savedCam: null,
       watchId: null,
@@ -3222,7 +3255,7 @@ function initRouting(map, config) {
 
     exitBtn.addEventListener('click', function() {
       api.exit();
-      driveBtn.innerHTML = 'Drive &#9654;';
+      resetGoButtons();
     });
 
     function setStatus(msg) {
@@ -3237,9 +3270,16 @@ function initRouting(map, config) {
       var proj = projectOnRoute(state.route, lat, lon);
       var totalDist = state.route.distance;
       var remaining = Math.max(0, totalDist - proj.distAlong);
-      // Average speed of the planned route; we don't have real-time segment
-      // speeds, so this is a reasonable ETA estimate.
-      var avgSpeed = state.route.time > 0 ? state.route.distance / state.route.time : 0;
+      // Remaining time. Drive mode uses the route's A*-computed time
+      // (car speeds). Walk/bike override with a flat avg speed since the
+      // routing graph only has car speeds.
+      var preset = MODE_PRESETS[state.mode] || MODE_PRESETS.drive;
+      var avgSpeed;
+      if (preset.speed != null) {
+        avgSpeed = preset.speed;
+      } else {
+        avgSpeed = state.route.time > 0 ? state.route.distance / state.route.time : 0;
+      }
       var remainingTime = avgSpeed > 0 ? remaining / avgSpeed : 0;
 
       // Find next turn ahead of us
@@ -3303,11 +3343,12 @@ function initRouting(map, config) {
       }
       state.lastBearing = bearing;
 
+      var p = MODE_PRESETS[state.mode] || MODE_PRESETS.drive;
       map.easeTo({
         center: [lon, lat],
         bearing: bearing,
-        pitch: 60,
-        zoom: 17,
+        pitch: p.pitch,
+        zoom: p.zoom,
         duration: 600,
         easing: function(t) { return t; }
       });
@@ -3320,13 +3361,14 @@ function initRouting(map, config) {
     var api = {
       get active() { return state.active; },
       setRoute: function(r) { state.route = r; state.lastBearing = null; },
-      enter: function() {
+      enter: function(mode) {
         if (state.active) return;
         if (!lastRoute) return;
         if (!navigator.geolocation) {
           setStatus('Geolocation not supported in this browser');
           return;
         }
+        state.mode = MODE_PRESETS[mode] ? mode : 'drive';
         state.active = true;
         state.route = lastRoute;
         state.savedCam = {
@@ -3345,7 +3387,8 @@ function initRouting(map, config) {
         setStatus('');
         // Immediate camera shift so the user sees the perspective change
         // before the first fix arrives.
-        map.easeTo({ pitch: 60, zoom: 17, duration: 600 });
+        var p = MODE_PRESETS[state.mode];
+        map.easeTo({ pitch: p.pitch, zoom: p.zoom, duration: 600 });
         try {
           state.watchId = navigator.geolocation.watchPosition(
             onPosition,
@@ -3385,15 +3428,26 @@ function initRouting(map, config) {
     return api;
   })();
 
-  driveBtn.addEventListener('click', function() {
-    if (!lastRoute) return;
-    if (driveMode.active) {
-      driveMode.exit();
-      driveBtn.innerHTML = 'Drive &#9654;';
-    } else {
-      driveMode.enter();
-      if (driveMode.active) driveBtn.textContent = 'Exit driving';
-    }
+  Object.keys(modeBtns).forEach(function(mode) {
+    modeBtns[mode].addEventListener('click', function() {
+      if (!lastRoute) return;
+      if (driveMode.active) {
+        driveMode.exit();
+        resetGoButtons();
+        return;
+      }
+      driveMode.enter(mode);
+      if (driveMode.active) {
+        Object.keys(modeBtns).forEach(function(m) {
+          if (m === mode) {
+            modeBtns[m].classList.add('active-mode');
+            modeBtns[m].textContent = 'Exit';
+          } else {
+            modeBtns[m].classList.add('hidden-mode');
+          }
+        });
+      }
+    });
   });
 
   // Keep HUD units in sync with the scale bar unit toggle

--- a/scripts/sync-drive-viewer.sh
+++ b/scripts/sync-drive-viewer.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Populate web/drive/viewer/ with the bits the Firebase PWA needs:
+#   - resources/viewer/index.html        (canonical viewer — unmodified)
+#   - maplibre-gl.js + .css               (same version the ZIM builder uses)
+#   - fzstd.js                            (zstd decoder for ZIM clusters)
+#
+# The PWA's service worker caches these as the "shell" on install; after
+# that, all other viewer requests (tiles, fonts, map-config.json, etc.)
+# are served from the user's local ZIM file via zim-reader.js.
+#
+# Run from repo root. Intended to be invoked by `firebase deploy`'s
+# predeploy hook (see firebase.json) and by anyone iterating locally.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+OUT="web/drive/viewer"
+MAPLIBRE_VERSION="5.23.0"
+FZSTD_VERSION="0.1.1"
+
+mkdir -p "$OUT"
+
+# curl with retry — CDNs occasionally 503 during deploys.
+fetch() {
+  local url="$1" out="$2"
+  for attempt in 1 2 3 4; do
+    if curl -fsSL "$url" -o "$out"; then return 0; fi
+    sleep $((attempt * 2))
+  done
+  echo "  FAILED after 4 attempts: $url" >&2
+  return 1
+}
+
+# 1. Copy the canonical viewer. We copy (not symlink) so firebase deploy's
+#    tarball sees a plain file regardless of the host filesystem.
+cp "resources/viewer/index.html" "$OUT/index.html"
+echo "  viewer HTML  → $OUT/index.html ($(wc -c < "$OUT/index.html") bytes)"
+
+# 2. Download MapLibre. Already on disk? Skip.
+MAPLIBRE_BASE="https://unpkg.com/maplibre-gl@${MAPLIBRE_VERSION}/dist"
+for asset in maplibre-gl.js maplibre-gl.css; do
+  target="$OUT/$asset"
+  if [ ! -s "$target" ]; then
+    echo "  fetching     → $target"
+    fetch "$MAPLIBRE_BASE/$asset" "$target"
+  else
+    echo "  cached       → $target"
+  fi
+done
+
+# 3. Download fzstd (MIT) for ZSTD cluster decompression. Lives one dir
+#    up from the viewer — only the service worker consumes it, not the
+#    viewer itself.
+FZSTD_URL="https://unpkg.com/fzstd@${FZSTD_VERSION}/umd/index.js"
+fzstd_target="$(dirname "$OUT")/fzstd.js"
+if [ ! -s "$fzstd_target" ]; then
+  echo "  fetching     → $fzstd_target"
+  fetch "$FZSTD_URL" "$fzstd_target"
+else
+  echo "  cached       → $fzstd_target"
+fi
+
+# 4. Emit a version stamp so the SW can bust the shell cache when we
+#    change anything here. Hash of concatenated asset sizes — cheap but
+#    stable enough for our purposes.
+STAMP=$(sha1sum "$OUT"/*.* "$fzstd_target" | sha1sum | awk '{print substr($1,1,10)}')
+echo "$STAMP" > "$OUT/.version"
+echo "  version stamp: $STAMP"
+
+echo "web/drive/viewer ready."

--- a/web/drive/index.html
+++ b/web/drive/index.html
@@ -2,611 +2,292 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="theme-color" content="#0b1220">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-<meta name="apple-mobile-web-app-title" content="StreetZim Drive">
+<meta name="apple-mobile-web-app-title" content="StreetZim">
 <meta name="mobile-web-app-capable" content="yes">
-<title>StreetZim Drive — test harness</title>
+<title>StreetZim — Offline Maps</title>
 <link rel="manifest" href="manifest.webmanifest">
 <link rel="apple-touch-icon" href="icon-192.png">
-<link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.23.0/dist/maplibre-gl.css">
-<script src="https://unpkg.com/maplibre-gl@5.23.0/dist/maplibre-gl.js"></script>
 <style>
   :root {
-    --ui-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-    --panel-bg: rgba(17,24,39,0.92);
-    --text: #fff;
-    --text-dim: rgba(255,255,255,0.78);
+    --bg: #0b1220;
+    --card: #131c2e;
+    --card-hover: #182339;
+    --text: #e6edf7;
+    --text-dim: #94a3b8;
     --accent: #2563eb;
     --accent-hover: #1d4ed8;
-    --warn-bg: rgba(234,179,8,0.18);
-    --warn-fg: #fde68a;
+    --border: rgba(255,255,255,0.08);
+    --ok: #22c55e;
+    --warn: #fbbf24;
   }
+  * { box-sizing: border-box; }
   html, body {
-    margin: 0; padding: 0; height: 100%;
-    background: #111; color: var(--text);
-    font-family: var(--ui-font);
-    overscroll-behavior: none;
+    margin: 0; padding: 0; min-height: 100%;
+    background: var(--bg); color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    line-height: 1.55; -webkit-font-smoothing: antialiased;
   }
-  #map { position: absolute; inset: 0; }
-
-  /* Top status / help */
-  #banner {
-    position: absolute; top: 0; left: 0; right: 0;
-    padding: max(env(safe-area-inset-top), 10px) 12px 10px;
-    background: linear-gradient(180deg, rgba(17,24,39,0.88), rgba(17,24,39,0));
-    color: var(--text); font-size: 13px; line-height: 1.35;
-    pointer-events: none; z-index: 2;
+  body {
+    padding: max(env(safe-area-inset-top), 16px) 16px
+            max(env(safe-area-inset-bottom), 16px);
+    max-width: 620px; margin: 0 auto;
   }
-  #banner strong { font-weight: 600; }
-  #banner.hidden { display: none; }
-
-  /* Bottom action bar */
-  #actionbar {
-    position: absolute; left: 10px; right: 10px;
-    bottom: max(env(safe-area-inset-bottom), 10px);
-    z-index: 4; display: flex; gap: 8px;
-    pointer-events: none;
+  h1 {
+    font-size: 24px; font-weight: 700; margin: 24px 0 8px;
+    letter-spacing: -0.3px;
   }
-  #actionbar button {
-    flex: 1; pointer-events: auto;
-    font-family: var(--ui-font); font-size: 14px; font-weight: 600;
-    padding: 12px 14px; border-radius: 10px; border: none;
-    background: var(--panel-bg); color: var(--text);
-    backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
-    box-shadow: 0 4px 16px rgba(0,0,0,0.35);
-    cursor: pointer;
+  p { color: var(--text-dim); }
+  .muted { color: var(--text-dim); font-size: 13px; }
+  .card {
+    background: var(--card); border: 1px solid var(--border);
+    border-radius: 14px; padding: 16px; margin: 16px 0;
   }
-  #actionbar button:disabled { opacity: 0.5; }
-  #actionbar button.primary { background: var(--accent); }
-  #actionbar button.primary:hover { background: var(--accent-hover); }
-
-  /* Driving HUD — mirrors the ZIM viewer's style */
-  #drive-hud {
-    display: none; position: absolute;
-    top: max(env(safe-area-inset-top), 10px); left: 10px; right: 10px;
-    z-index: 5; pointer-events: auto;
-    background: var(--panel-bg); color: var(--text);
-    border-radius: 12px; padding: 12px 14px;
-    box-shadow: 0 4px 16px rgba(0,0,0,0.35);
-    backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
+  .card.ok { border-color: rgba(34,197,94,0.35); }
+  .card.warn { border-color: rgba(251,191,36,0.35); }
+  .row { display: flex; gap: 12px; align-items: center; }
+  .row.stack { flex-direction: column; align-items: stretch; }
+  button, .btn {
+    font-family: inherit; font-size: 15px; font-weight: 600;
+    padding: 12px 16px; border-radius: 10px; border: none;
+    background: var(--accent); color: #fff; cursor: pointer;
+    display: inline-flex; align-items: center; justify-content: center;
+    gap: 8px; text-decoration: none;
   }
-  #drive-hud.visible { display: block; }
-  #drive-hud-row {
-    display: flex; align-items: center; gap: 12px;
+  button:hover, .btn:hover { background: var(--accent-hover); }
+  button:disabled { opacity: 0.5; cursor: default; }
+  .btn-secondary {
+    background: transparent; color: var(--text);
+    border: 1px solid var(--border);
   }
-  #drive-arrow {
-    width: 48px; height: 48px; flex-shrink: 0;
-    display: flex; align-items: center; justify-content: center;
-    background: rgba(255,255,255,0.1); border-radius: 10px;
-    font-size: 30px; line-height: 1;
+  .btn-secondary:hover { background: var(--card-hover); }
+  .btn-danger {
+    background: transparent; color: #fca5a5;
+    border: 1px solid rgba(248,113,113,0.35);
   }
-  #drive-text { flex: 1; min-width: 0; }
-  #drive-dist { font-size: 24px; font-weight: 700; line-height: 1.1; }
-  #drive-street {
-    font-size: 13px; color: var(--text-dim);
-    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-    margin-top: 2px;
+  .btn-danger:hover { background: rgba(248,113,113,0.1); }
+  #status { font-size: 13px; color: var(--text-dim); margin-top: 6px; word-break: break-word; }
+  #status.err { color: #fca5a5; }
+  #status.ok { color: #86efac; }
+  #hint { font-size: 12px; color: var(--text-dim); margin-top: 10px; }
+  .dot {
+    display: inline-block; width: 8px; height: 8px; border-radius: 50%;
+    background: var(--text-dim); margin-right: 6px; vertical-align: middle;
   }
-  #drive-exit {
-    flex-shrink: 0; background: rgba(255,255,255,0.12);
-    border: none; border-radius: 8px; color: var(--text);
-    font-family: var(--ui-font); font-size: 12px; font-weight: 700;
-    padding: 10px 14px; cursor: pointer; letter-spacing: 0.5px;
+  .dot.ok { background: var(--ok); }
+  .dot.warn { background: var(--warn); }
+  input[type=file] { display: none; }
+  details { margin-top: 16px; }
+  details summary { cursor: pointer; color: var(--text-dim); font-size: 13px; }
+  details pre {
+    background: #0a0f1c; border: 1px solid var(--border); border-radius: 6px;
+    padding: 10px; font-size: 11px; overflow-x: auto; color: var(--text-dim);
   }
-  #drive-hud-eta {
-    margin-top: 8px; padding-top: 8px;
-    border-top: 1px solid rgba(255,255,255,0.12);
-    display: flex; justify-content: space-between;
-    font-size: 12px; color: var(--text-dim);
-  }
-  #drive-hud-eta strong { color: var(--text); font-weight: 600; }
-  #drive-status {
-    display: none; margin-top: 8px; padding: 6px 8px;
-    background: var(--warn-bg); color: var(--warn-fg);
-    border-radius: 6px; font-size: 12px;
-  }
-  #drive-status.visible { display: block; }
-
-  /* Settings (unit toggle) */
-  #unit-toggle {
-    position: absolute; right: 10px;
-    bottom: calc(max(env(safe-area-inset-bottom), 10px) + 58px);
-    z-index: 3; pointer-events: auto;
-    background: var(--panel-bg); color: var(--text);
-    border: none; border-radius: 8px;
-    padding: 8px 12px; font-size: 12px; font-weight: 600;
-    box-shadow: 0 4px 16px rgba(0,0,0,0.35);
-    backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
-    cursor: pointer;
-  }
-
-  /* Hide default MapLibre controls a bit from the edges on mobile */
-  .maplibregl-ctrl-top-right { top: max(env(safe-area-inset-top), 10px); }
 </style>
 </head>
 <body>
-<div id="map"></div>
 
-<div id="banner">
-  <strong>Tap a map point to set origin</strong>, tap again for destination. Then hit <strong>Drive</strong>.
-</div>
+<h1>StreetZim</h1>
+<p>Offline maps — pick a <code>.zim</code> file you've downloaded and the viewer will render it with zero network needed.</p>
 
-<button id="unit-toggle" title="Toggle mi / km">mi</button>
-
-<div id="actionbar">
-  <button id="btn-locate" title="Center on me">📍 Me</button>
-  <button id="btn-reset" disabled>Reset</button>
-  <button id="btn-drive" class="primary" disabled>Drive ▶</button>
-</div>
-
-<div id="drive-hud" aria-hidden="true">
-  <div id="drive-hud-row">
-    <div id="drive-arrow">↑</div>
-    <div id="drive-text">
-      <div id="drive-dist">—</div>
-      <div id="drive-street">Getting location…</div>
-    </div>
-    <button id="drive-exit">EXIT</button>
+<div class="card" id="status-card">
+  <div class="row">
+    <span id="status-dot" class="dot"></span>
+    <strong id="status-title">Checking…</strong>
   </div>
-  <div id="drive-hud-eta">
-    <span>Remaining: <strong id="drive-remaining">—</strong></span>
-    <span>ETA: <strong id="drive-eta">—</strong></span>
-  </div>
-  <div id="drive-status"></div>
+  <div id="status" class="muted">Initializing service worker…</div>
 </div>
+
+<div class="card">
+  <div class="row stack">
+    <button id="pick-btn">Choose a ZIM file</button>
+    <a id="open-btn" class="btn btn-secondary" href="viewer/" style="display:none;">Open viewer</a>
+    <button id="clear-btn" class="btn-danger" style="display:none;">Remove loaded ZIM</button>
+  </div>
+  <div id="hint">
+    Pick any <code>osm-*.zim</code> produced by <code>create_osm_zim.py</code>
+    (or download one from <a href="/">streetzim.web.app</a>).
+    On Chrome / Edge the file handle is remembered across launches;
+    on Safari you may need to re-pick it after a reboot.
+  </div>
+</div>
+
+<details>
+  <summary>Advanced / diagnostics</summary>
+  <pre id="diag"></pre>
+</details>
+
+<!-- Hidden fallback picker for browsers without showOpenFilePicker -->
+<input type="file" id="file-fallback" accept=".zim,application/octet-stream">
 
 <script>
-// --- StreetZim Drive test harness ---
-// Self-contained page intended to live on Firebase hosting so you can test
-// the driving-mode UX on a phone without rebuilding a ZIM.
-//
-// Phase 2a: online raster OSM tiles + tap-to-plan fake route (straight line).
-// Phase 2b will swap the tap-fake route for a local-ZIM reader + real routing.
-
 (function() {
   'use strict';
 
-  // ---------- helpers shared with the ZIM viewer ----------
+  const pickBtn  = document.getElementById('pick-btn');
+  const openBtn  = document.getElementById('open-btn');
+  const clearBtn = document.getElementById('clear-btn');
+  const fileFallback = document.getElementById('file-fallback');
+  const statusEl = document.getElementById('status');
+  const statusTitle = document.getElementById('status-title');
+  const statusDot = document.getElementById('status-dot');
+  const statusCard = document.getElementById('status-card');
+  const diagEl = document.getElementById('diag');
 
-  function haversineMeters(lat1, lon1, lat2, lon2) {
-    var R = 6371000;
-    var toRad = Math.PI / 180;
-    var dLat = (lat2 - lat1) * toRad;
-    var dLon = (lon2 - lon1) * toRad;
-    var a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-            Math.cos(lat1 * toRad) * Math.cos(lat2 * toRad) *
-            Math.sin(dLon / 2) * Math.sin(dLon / 2);
-    return 2 * R * Math.asin(Math.min(1, Math.sqrt(a)));
+  const log = [];
+  function dbg() {
+    log.push('[' + new Date().toISOString().substr(11, 12) + '] ' +
+      [...arguments].map((a) => typeof a === 'object' ? JSON.stringify(a) : String(a)).join(' '));
+    diagEl.textContent = log.slice(-60).join('\n');
+    if (window.console && console.log) console.log.apply(console, ['[streetzim]'].concat([...arguments]));
   }
 
-  function bearingDeg(lat1, lon1, lat2, lon2) {
-    var toRad = Math.PI / 180, toDeg = 180 / Math.PI;
-    var y = Math.sin((lon2 - lon1) * toRad) * Math.cos(lat2 * toRad);
-    var x = Math.cos(lat1 * toRad) * Math.sin(lat2 * toRad) -
-            Math.sin(lat1 * toRad) * Math.cos(lat2 * toRad) * Math.cos((lon2 - lon1) * toRad);
-    return (Math.atan2(y, x) * toDeg + 360) % 360;
+  function setStatus(kind, title, msg) {
+    statusDot.classList.remove('ok', 'warn');
+    statusCard.classList.remove('ok', 'warn');
+    statusEl.classList.remove('ok', 'err');
+    if (kind === 'ok')   { statusDot.classList.add('ok');   statusCard.classList.add('ok');   statusEl.classList.add('ok'); }
+    if (kind === 'warn') { statusDot.classList.add('warn'); statusCard.classList.add('warn'); }
+    if (kind === 'err')  { statusEl.classList.add('err'); }
+    statusTitle.textContent = title;
+    statusEl.textContent = msg || '';
   }
 
-  // Cumulative distances per coord + synthetic turn boundaries.
-  // For a tap-fake route, we interpolate intermediate points so the
-  // camera has enough tangent samples for smooth bearing tracking.
-  function augmentRouteForDriving(coordsLngLat, speedMps) {
-    var cumM = new Float64Array(coordsLngLat.length);
-    for (var i = 1; i < coordsLngLat.length; i++) {
-      cumM[i] = cumM[i - 1] + haversineMeters(
-        coordsLngLat[i - 1][1], coordsLngLat[i - 1][0],
-        coordsLngLat[i][1],     coordsLngLat[i][0]
-      );
-    }
-    var total = cumM[cumM.length - 1];
-    var t = speedMps > 0 ? total / speedMps : 0;
-    return { coords: coordsLngLat, cumM: cumM, distance: total, time: t, turns: [] };
+  // ---------- Service worker registration ----------
+
+  if (!('serviceWorker' in navigator)) {
+    setStatus('err', 'Unsupported browser',
+      'This viewer needs a browser with Service Worker support.');
+    pickBtn.disabled = true;
+    return;
   }
 
-  function projectOnRoute(route, lat, lon) {
-    var coords = route.coords, cumM = route.cumM;
-    var best = { d2: Infinity, segIdx: 0, t: 0 };
-    var toRad = Math.PI / 180;
-    var cosLat = Math.cos(lat * toRad);
-    function xy(ll) { return [(ll[0] - lon) * cosLat, (ll[1] - lat)]; }
-    for (var i = 0; i < coords.length - 1; i++) {
-      var a = xy(coords[i]);
-      var b = xy(coords[i + 1]);
-      var px = -a[0], py = -a[1];
-      var vx = b[0] - a[0], vy = b[1] - a[1];
-      var len2 = vx * vx + vy * vy;
-      var tt = len2 > 0 ? (px * vx + py * vy) / len2 : 0;
-      if (tt < 0) tt = 0; else if (tt > 1) tt = 1;
-      var cx = a[0] + tt * vx, cy = a[1] + tt * vy;
-      var d2 = cx * cx + cy * cy;
-      if (d2 < best.d2) { best.d2 = d2; best.segIdx = i; best.t = tt; }
-    }
-    var si = best.segIdx;
-    var distAlong = cumM[si] + best.t * (cumM[si + 1] - cumM[si]);
-    var tangent = bearingDeg(
-      coords[si][1], coords[si][0],
-      coords[si + 1][1], coords[si + 1][0]
-    );
-    var offMeters = Math.sqrt(best.d2) * 111320;
-    return { distAlong: distAlong, segIdx: si, t: best.t, bearing: tangent, offMeters: offMeters };
-  }
+  let swRegistration = null;
 
-  var units = (localStorage.getItem('streetzim.units') || 'imperial');
-
-  function setUnits(u) {
-    units = u;
-    localStorage.setItem('streetzim.units', u);
-    unitBtn.textContent = (u === 'imperial') ? 'mi' : 'km';
-  }
-
-  function formatDistance(meters) {
-    if (units === 'imperial') {
-      var feet = meters * 3.28084;
-      if (feet < 1000) return Math.round(feet / 10) * 10 + ' ft';
-      var miles = meters / 1609.344;
-      if (miles < 10) return miles.toFixed(1) + ' mi';
-      return Math.round(miles) + ' mi';
-    }
-    if (meters < 1000) return Math.round(meters / 10) * 10 + ' m';
-    if (meters < 10000) return (meters / 1000).toFixed(1) + ' km';
-    return Math.round(meters / 1000) + ' km';
-  }
-
-  function formatDuration(seconds) {
-    if (!isFinite(seconds) || seconds < 0) return '—';
-    if (seconds < 60) return Math.round(seconds) + ' sec';
-    var mins = Math.round(seconds / 60);
-    if (mins < 60) return mins + ' min';
-    var hrs = Math.floor(mins / 60);
-    var rem = mins % 60;
-    return hrs + ' hr ' + rem + ' min';
-  }
-
-  function formatEtaClock(seconds) {
-    if (!isFinite(seconds) || seconds < 0) return '—';
-    try {
-      var fmt = new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' });
-      return fmt.format(new Date(Date.now() + seconds * 1000));
-    } catch (e) { return '—'; }
-  }
-
-  function turnGlyph(deltaDeg) {
-    var d = ((deltaDeg + 540) % 360) - 180;
-    if (d > 135 || d < -135) return '↺';
-    if (d > 30)  return '↷';
-    if (d < -30) return '↶';
-    if (d > 15)  return '↗';
-    if (d < -15) return '↖';
-    return '↑';
-  }
-
-  // ---------- DOM refs ----------
-  var banner = document.getElementById('banner');
-  var unitBtn = document.getElementById('unit-toggle');
-  var locateBtn = document.getElementById('btn-locate');
-  var resetBtn = document.getElementById('btn-reset');
-  var driveBtn = document.getElementById('btn-drive');
-  var hudEl = document.getElementById('drive-hud');
-  var distEl = document.getElementById('drive-dist');
-  var streetEl = document.getElementById('drive-street');
-  var arrowEl = document.getElementById('drive-arrow');
-  var exitBtn = document.getElementById('drive-exit');
-  var remainEl = document.getElementById('drive-remaining');
-  var etaEl = document.getElementById('drive-eta');
-  var statusEl = document.getElementById('drive-status');
-
-  setUnits(units);
-  unitBtn.addEventListener('click', function() {
-    setUnits(units === 'imperial' ? 'metric' : 'imperial');
-  });
-
-  // ---------- MapLibre ----------
-  var map = new maplibregl.Map({
-    container: 'map',
-    style: {
-      version: 8,
-      sources: {
-        osm: {
-          type: 'raster',
-          tiles: [
-            'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
-            'https://b.tile.openstreetmap.org/{z}/{x}/{y}.png',
-            'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png'
-          ],
-          tileSize: 256,
-          maxzoom: 19,
-          attribution: '© OpenStreetMap contributors'
-        }
-      },
-      layers: [{ id: 'osm', type: 'raster', source: 'osm' }]
-    },
-    center: [-122.4194, 37.7749],
-    zoom: 12,
-    maxZoom: 19,
-    attributionControl: true
-  });
-  map.addControl(new maplibregl.NavigationControl({ showCompass: true }), 'top-right');
-  map.addControl(new maplibregl.GeolocateControl({
-    positionOptions: { enableHighAccuracy: true },
-    trackUserLocation: true,
-    showUserHeading: true
-  }), 'top-right');
-
-  // ---------- Tap-to-plan synthetic route ----------
-  var origin = null, dest = null;
-  var originMarker = null, destMarker = null;
-  var routeSourceAdded = false;
-  var route = null;  // augmented route (from augmentRouteForDriving)
-
-  function makeDot(color) {
-    var el = document.createElement('div');
-    el.style.cssText =
-      'width:14px;height:14px;border-radius:50%;background:' + color +
-      ';border:3px solid #fff;box-shadow:0 1px 4px rgba(0,0,0,0.5);';
-    return el;
-  }
-
-  function drawRoute() {
-    if (!origin || !dest) return;
-    // Interpolate along the great-circle approximation — 40 steps is plenty
-    // for straight-line driving, gives the camera smooth tangent samples.
-    var steps = 40;
-    var coords = [];
-    for (var i = 0; i <= steps; i++) {
-      var t = i / steps;
-      coords.push([
-        origin[0] + (dest[0] - origin[0]) * t,
-        origin[1] + (dest[1] - origin[1]) * t
-      ]);
-    }
-    // Assume ~35 mph average; used only for ETA estimate
-    var avg = 15.6; // m/s ≈ 35 mph
-    route = augmentRouteForDriving(coords, avg);
-
-    var geojson = { type: 'Feature', geometry: { type: 'LineString', coordinates: coords } };
-    if (routeSourceAdded) {
-      map.getSource('route').setData(geojson);
-    } else {
-      map.addSource('route', { type: 'geojson', data: geojson });
-      map.addLayer({
-        id: 'route-outline', type: 'line', source: 'route',
-        paint: { 'line-color': '#1e40af', 'line-width': 8, 'line-opacity': 0.4 }
-      });
-      map.addLayer({
-        id: 'route-line', type: 'line', source: 'route',
-        paint: { 'line-color': '#2563eb', 'line-width': 4, 'line-opacity': 0.9 }
-      });
-      routeSourceAdded = true;
-    }
-    var bounds = coords.reduce(function(b, c) { return b.extend(c); },
-      new maplibregl.LngLatBounds(coords[0], coords[0]));
-    map.fitBounds(bounds, { padding: 80, duration: 700 });
-    driveBtn.disabled = false;
-    banner.classList.add('hidden');
-  }
-
-  function clearPlan() {
-    if (driveMode.active) driveMode.exit();
-    origin = dest = null;
-    route = null;
-    if (originMarker) { originMarker.remove(); originMarker = null; }
-    if (destMarker) { destMarker.remove(); destMarker = null; }
-    if (routeSourceAdded) {
-      try { map.removeLayer('route-line'); } catch (e) {}
-      try { map.removeLayer('route-outline'); } catch (e) {}
-      try { map.removeSource('route'); } catch (e) {}
-      routeSourceAdded = false;
-    }
-    driveBtn.disabled = true;
-    resetBtn.disabled = true;
-    banner.classList.remove('hidden');
-  }
-
-  resetBtn.addEventListener('click', clearPlan);
-
-  map.on('click', function(e) {
-    if (driveMode.active) return;
-    var ll = [e.lngLat.lng, e.lngLat.lat];
-    if (!origin) {
-      origin = ll;
-      originMarker = new maplibregl.Marker({ element: makeDot('#22c55e') })
-        .setLngLat(ll).addTo(map);
-      resetBtn.disabled = false;
-    } else if (!dest) {
-      dest = ll;
-      destMarker = new maplibregl.Marker({ element: makeDot('#ef4444') })
-        .setLngLat(ll).addTo(map);
-      drawRoute();
-    } else {
-      // Third tap — treat as new origin; clear and restart
-      clearPlan();
-      origin = ll;
-      originMarker = new maplibregl.Marker({ element: makeDot('#22c55e') })
-        .setLngLat(ll).addTo(map);
-      resetBtn.disabled = false;
-    }
-  });
-
-  locateBtn.addEventListener('click', function() {
-    if (!navigator.geolocation) return;
-    navigator.geolocation.getCurrentPosition(function(p) {
-      map.easeTo({
-        center: [p.coords.longitude, p.coords.latitude],
-        zoom: Math.max(15, map.getZoom()),
-        duration: 800
-      });
-    }, function() {}, { enableHighAccuracy: true, timeout: 10000, maximumAge: 60000 });
-  });
-
-  // ---------- Driving mode (mirrors the ZIM viewer's logic) ----------
-
-  var driveMode = (function() {
-    var state = {
-      active: false,
-      route: null,
-      savedCam: null,
-      watchId: null,
-      lastBearing: null,
-      offRouteSince: 0
-    };
-
-    function setStatus(msg) {
-      if (!msg) { statusEl.classList.remove('visible'); statusEl.textContent = ''; return; }
-      statusEl.textContent = msg;
-      statusEl.classList.add('visible');
-    }
-
-    function onPosition(pos) {
-      if (!state.active || !state.route) return;
-      var lat = pos.coords.latitude, lon = pos.coords.longitude;
-      var proj = projectOnRoute(state.route, lat, lon);
-      var remaining = Math.max(0, state.route.distance - proj.distAlong);
-      var avgSpeed = state.route.time > 0 ? state.route.distance / state.route.time : 0;
-      var remainingTime = avgSpeed > 0 ? remaining / avgSpeed : 0;
-
-      distEl.textContent = formatDistance(remaining);
-      streetEl.textContent = remaining < 30 ? 'Arriving at destination' : 'Continue to destination';
-      arrowEl.textContent = remaining < 30 ? '◎' : '↑';
-      remainEl.textContent = formatDistance(remaining) + ' · ' + formatDuration(remainingTime);
-      etaEl.textContent = formatEtaClock(remainingTime);
-
-      if (proj.offMeters > 60) {
-        if (!state.offRouteSince) state.offRouteSince = Date.now();
-        if (Date.now() - state.offRouteSince > 6000) {
-          setStatus('Off route (' + Math.round(proj.offMeters) + ' m).');
-        }
-      } else {
-        state.offRouteSince = 0;
-        setStatus('');
-      }
-
-      var speed = pos.coords.speed;
-      var heading = pos.coords.heading;
-      var bearing;
-      if (typeof heading === 'number' && !isNaN(heading) && speed != null && speed > 1) {
-        bearing = heading;
-      } else {
-        bearing = proj.bearing;
-      }
-      if (state.lastBearing != null) {
-        var delta = ((bearing - state.lastBearing + 540) % 360) - 180;
-        if (Math.abs(delta) < 2) bearing = state.lastBearing;
-      }
-      state.lastBearing = bearing;
-
-      map.easeTo({
-        center: [lon, lat],
-        bearing: bearing, pitch: 60, zoom: 17,
-        duration: 600,
-        easing: function(t) { return t; }
-      });
-    }
-
-    function onError(err) {
-      setStatus('Location unavailable: ' + (err && err.message ? err.message : 'error'));
-    }
-
-    var api = {
-      get active() { return state.active; },
-      enter: function() {
-        if (state.active || !route) return;
-        if (!navigator.geolocation) { setStatus('Geolocation not supported'); return; }
-        state.active = true;
-        state.route = route;
-        state.savedCam = {
-          center: map.getCenter(),
-          zoom: map.getZoom(),
-          bearing: map.getBearing(),
-          pitch: map.getPitch()
+  async function ensureSW() {
+    const reg = await navigator.serviceWorker.register('sw.js', { scope: './' });
+    // Wait until there's an active, controlling SW — fetch interception
+    // only works once the page is controlled.
+    if (!navigator.serviceWorker.controller) {
+      await new Promise((resolve) => {
+        const check = () => {
+          if (navigator.serviceWorker.controller) resolve();
+          else setTimeout(check, 100);
         };
-        hudEl.classList.add('visible');
-        hudEl.setAttribute('aria-hidden', 'false');
-        distEl.textContent = '—';
-        streetEl.textContent = 'Getting location…';
-        arrowEl.textContent = '↑';
-        remainEl.textContent = '—';
-        etaEl.textContent = '—';
-        setStatus('');
-        driveBtn.textContent = 'Exit driving';
-        map.easeTo({ pitch: 60, zoom: 17, duration: 600 });
-        try {
-          state.watchId = navigator.geolocation.watchPosition(
-            onPosition, onError,
-            { enableHighAccuracy: true, timeout: 15000, maximumAge: 2000 }
-          );
-        } catch (e) {
-          setStatus('Could not start location tracking');
-          state.active = false;
-          hudEl.classList.remove('visible');
-          driveBtn.textContent = 'Drive ▶';
-        }
-      },
-      exit: function() {
-        if (!state.active) return;
-        state.active = false;
-        if (state.watchId != null) {
-          try { navigator.geolocation.clearWatch(state.watchId); } catch (e) {}
-          state.watchId = null;
-        }
-        hudEl.classList.remove('visible');
-        hudEl.setAttribute('aria-hidden', 'true');
-        if (state.savedCam) {
-          map.easeTo({
-            center: state.savedCam.center,
-            zoom: state.savedCam.zoom,
-            bearing: state.savedCam.bearing,
-            pitch: state.savedCam.pitch,
-            duration: 800
-          });
-          state.savedCam = null;
-        }
-        state.route = null;
-        state.lastBearing = null;
-        state.offRouteSince = 0;
-        driveBtn.textContent = 'Drive ▶';
-      }
-    };
-    return api;
-  })();
-
-  driveBtn.addEventListener('click', function() {
-    if (!route) return;
-    if (driveMode.active) driveMode.exit();
-    else driveMode.enter();
-  });
-  exitBtn.addEventListener('click', function() { driveMode.exit(); });
-
-  // Keep screen awake while driving (best-effort; Safari/iOS 16.4+)
-  var wakeLock = null;
-  async function acquireWakeLock() {
-    try {
-      if ('wakeLock' in navigator) {
-        wakeLock = await navigator.wakeLock.request('screen');
-      }
-    } catch (e) { /* ignore */ }
-  }
-  function releaseWakeLock() {
-    if (wakeLock) { try { wakeLock.release(); } catch (e) {} wakeLock = null; }
-  }
-  document.addEventListener('visibilitychange', function() {
-    if (document.visibilityState === 'visible' && driveMode.active) acquireWakeLock();
-  });
-  // Patch enter/exit to toggle wake lock
-  var _enter = driveMode.enter, _exit = driveMode.exit;
-  driveMode.enter = function() { _enter.call(driveMode); if (driveMode.active) acquireWakeLock(); };
-  driveMode.exit  = function() { releaseWakeLock(); _exit.call(driveMode); };
-
-  // ---------- Service worker (offline shell) ----------
-  if ('serviceWorker' in navigator) {
-    window.addEventListener('load', function() {
-      navigator.serviceWorker.register('sw.js').catch(function(e) {
-        console.warn('[streetzim-drive] sw register failed', e);
+        check();
       });
+    }
+    return reg;
+  }
+
+  function askSW(msg) {
+    return new Promise((resolve, reject) => {
+      const ch = new MessageChannel();
+      ch.port1.onmessage = (e) => resolve(e.data);
+      const target = navigator.serviceWorker.controller;
+      if (!target) { reject(new Error('no active service worker')); return; }
+      target.postMessage(msg, [ch.port2]);
+      setTimeout(() => reject(new Error('SW message timeout')), 30000);
     });
   }
+
+  async function refreshStatus() {
+    try {
+      const r = await askSW({ type: 'status' });
+      if (r && r.ok && r.loaded) {
+        setStatus('ok', 'ZIM loaded',
+          'v' + r.info.version + ' · ' + r.info.articles.toLocaleString() + ' entries · ' +
+          r.info.sizeMB + ' MB');
+        openBtn.style.display = '';
+        clearBtn.style.display = '';
+        pickBtn.textContent = 'Change ZIM';
+      } else {
+        setStatus('warn', 'No ZIM loaded',
+          'Pick a file below — it stays in your browser, nothing uploaded.');
+        openBtn.style.display = 'none';
+        clearBtn.style.display = 'none';
+        pickBtn.textContent = 'Choose a ZIM file';
+      }
+    } catch (err) {
+      setStatus('err', 'Status check failed', String(err && err.message || err));
+    }
+  }
+
+  // ---------- File picker ----------
+
+  async function pickFile() {
+    try {
+      if (window.showOpenFilePicker) {
+        const [handle] = await window.showOpenFilePicker({
+          types: [{ description: 'ZIM files', accept: { 'application/octet-stream': ['.zim'] } }],
+          excludeAcceptAllOption: false,
+          multiple: false
+        });
+        return await handle.getFile();
+      }
+    } catch (err) {
+      if (err && err.name === 'AbortError') return null;
+      dbg('showOpenFilePicker failed, falling back to input', err);
+    }
+    return new Promise((resolve) => {
+      fileFallback.onchange = () => {
+        resolve(fileFallback.files && fileFallback.files[0] ? fileFallback.files[0] : null);
+      };
+      fileFallback.click();
+    });
+  }
+
+  async function loadZim(file) {
+    if (!file) return;
+    if (!/\.zim$/i.test(file.name) && file.type !== 'application/octet-stream') {
+      setStatus('warn', 'Not a .zim file',
+        'Got: ' + file.name + ' (' + (file.type || 'unknown type') + ')');
+      return;
+    }
+    setStatus('warn', 'Loading ZIM…',
+      file.name + ' · ' + (file.size / (1024 * 1024)).toFixed(1) + ' MB — opening header…');
+    try {
+      const resp = await askSW({ type: 'set-zim', blob: file, name: file.name });
+      if (!resp || !resp.ok) throw new Error(resp && resp.error || 'SW rejected file');
+      await refreshStatus();
+      // Small delay so the user sees the "ZIM loaded" flash before redirecting.
+      setTimeout(() => { window.location.href = 'viewer/'; }, 600);
+    } catch (err) {
+      setStatus('err', 'Failed to open ZIM', String(err && err.message || err));
+    }
+  }
+
+  pickBtn.addEventListener('click', async () => {
+    const file = await pickFile();
+    if (file) loadZim(file);
+  });
+
+  clearBtn.addEventListener('click', async () => {
+    if (!confirm('Remove the loaded ZIM from this browser?')) return;
+    try {
+      const r = await askSW({ type: 'clear-zim' });
+      if (!r || !r.ok) throw new Error(r && r.error || 'SW refused');
+      await refreshStatus();
+    } catch (err) {
+      setStatus('err', 'Clear failed', String(err && err.message || err));
+    }
+  });
+
+  // ---------- Boot ----------
+
+  (async () => {
+    try {
+      swRegistration = await ensureSW();
+      dbg('sw ready', swRegistration.scope);
+      await refreshStatus();
+    } catch (err) {
+      setStatus('err', 'Service worker registration failed',
+        String(err && err.message || err));
+    }
+  })();
 })();
 </script>
 </body>

--- a/web/drive/sw.js
+++ b/web/drive/sw.js
@@ -1,69 +1,292 @@
-// StreetZim Drive — minimal service worker for the PWA shell.
+// StreetZim Drive — service worker.
 //
-// Phase 2a goal: make "Add to Home Screen" work and keep the app shell
-// available when cell coverage is spotty. Map tiles still need network;
-// Phase 2b will move to a local-ZIM reader served via maplibregl.addProtocol.
+// Role: turn the Firebase-hosted /drive/ PWA into a fully offline viewer
+// backed by whichever .zim file the user picks. Responsibilities:
+//   1. Precache the viewer shell (HTML + MapLibre JS/CSS) on install.
+//   2. Intercept fetches from /drive/viewer/* and serve them either from
+//      the shell cache (known static assets) or from the user's local
+//      ZIM via ZimReader.
+//   3. Keep the ZIM Blob in IndexedDB so it survives SW termination and
+//      re-launches.
+//
+// After install + ZIM pick, the app works with zero network requests.
 
-const SHELL_CACHE = 'streetzim-drive-shell-v1';
+importScripts('./fzstd.js', './zim-reader.js');
+
+// Bump this when the shell changes (new maplibre, new viewer HTML, etc.).
+// The sync script writes a stamp to web/drive/viewer/.version which the
+// page reads on load and posts to the SW — we compare and clear stale
+// caches. For now just hand-bump on big changes.
+const SHELL_CACHE = 'streetzim-drive-shell-v2';
+
 const SHELL_URLS = [
   './',
   './index.html',
   './manifest.webmanifest',
-  'https://unpkg.com/maplibre-gl@5.23.0/dist/maplibre-gl.css',
-  'https://unpkg.com/maplibre-gl@5.23.0/dist/maplibre-gl.js'
+  './icon-192.png',
+  './icon-512.png',
+  './viewer/',
+  './viewer/index.html',
+  './viewer/maplibre-gl.js',
+  './viewer/maplibre-gl.css'
 ];
 
+// Files in /drive/viewer/ that are always part of the shell, never the
+// ZIM. Everything else under /drive/viewer/ is ZIM content.
+const VIEWER_SHELL_NAMES = new Set([
+  '', 'index.html', 'maplibre-gl.js', 'maplibre-gl.css'
+]);
+
+// ---------- IndexedDB helpers (no dependency) ----------
+
+const DB_NAME = 'streetzim-drive';
+const DB_VERSION = 1;
+const DB_STORE = 'zim';
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(DB_STORE)) {
+        db.createObjectStore(DB_STORE, { keyPath: 'id' });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function idbGet(id) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(DB_STORE, 'readonly');
+    const req = tx.objectStore(DB_STORE).get(id);
+    req.onsuccess = () => resolve(req.result || null);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function idbPut(record) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(DB_STORE, 'readwrite');
+    tx.objectStore(DB_STORE).put(record);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function idbDelete(id) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(DB_STORE, 'readwrite');
+    tx.objectStore(DB_STORE).delete(id);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+// ---------- ZIM reader (lazy singleton) ----------
+
+let readerPromise = null;  // Promise<ZimReader|null>
+
+function resetReader() {
+  readerPromise = null;
+}
+
+async function getReader() {
+  if (readerPromise) return readerPromise;
+  readerPromise = (async () => {
+    const rec = await idbGet('current');
+    if (!rec || !rec.blob) return null;
+    const r = new self.StreetZimReader(rec.blob);
+    await r.open();
+    return r;
+  })();
+  return readerPromise;
+}
+
+// ---------- Lifecycle ----------
+
 self.addEventListener('install', (event) => {
-  event.waitUntil(
-    caches.open(SHELL_CACHE).then((cache) =>
-      // Don't fail install if one asset refuses to cache (CDN CORS quirks etc.)
-      Promise.all(SHELL_URLS.map((url) =>
-        cache.add(url).catch((err) => console.warn('[sw] skip', url, err))
-      ))
-    ).then(() => self.skipWaiting())
-  );
+  event.waitUntil((async () => {
+    const cache = await caches.open(SHELL_CACHE);
+    // Don't fail install if one asset can't be cached — we prefer a
+    // partly-working PWA over none at all.
+    await Promise.all(SHELL_URLS.map((url) =>
+      cache.add(url).catch((err) => console.warn('[sw] skip', url, err))
+    ));
+    await self.skipWaiting();
+  })());
 });
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(
-    caches.keys().then((names) =>
-      Promise.all(names.filter((n) => n !== SHELL_CACHE).map((n) => caches.delete(n)))
-    ).then(() => self.clients.claim())
-  );
+  event.waitUntil((async () => {
+    const names = await caches.keys();
+    await Promise.all(
+      names.filter((n) => n !== SHELL_CACHE).map((n) => caches.delete(n))
+    );
+    await self.clients.claim();
+  })());
 });
+
+// ---------- Messages from the page ----------
+
+self.addEventListener('message', (event) => {
+  const msg = event.data || {};
+  event.waitUntil((async () => {
+    let reply = { ok: true };
+    try {
+      if (msg.type === 'set-zim') {
+        await idbPut({
+          id: 'current',
+          blob: msg.blob,
+          name: msg.name || 'zim',
+          addedAt: Date.now()
+        });
+        resetReader();
+        // Force-open so the page sees any error immediately.
+        const r = await getReader();
+        reply.info = r ? r.info : null;
+      } else if (msg.type === 'clear-zim') {
+        await idbDelete('current');
+        resetReader();
+      } else if (msg.type === 'status') {
+        const r = await getReader().catch(() => null);
+        reply.info = r ? r.info : null;
+        reply.loaded = !!r;
+      } else {
+        reply = { ok: false, error: 'unknown message type' };
+      }
+    } catch (err) {
+      reply = { ok: false, error: String(err && err.message || err) };
+    }
+    if (event.ports && event.ports[0]) event.ports[0].postMessage(reply);
+  })());
+});
+
+// ---------- Fetch interception ----------
+
+function rangeResponse(data, range, mime) {
+  // Parse "bytes=start-end" (end optional)
+  const m = /^bytes=(\d+)-(\d*)$/.exec(range);
+  if (!m) return null;
+  const start = parseInt(m[1], 10);
+  const end = m[2] ? parseInt(m[2], 10) : data.byteLength - 1;
+  if (isNaN(start) || start >= data.byteLength) return null;
+  const slice = data.subarray(start, Math.min(end + 1, data.byteLength));
+  return new Response(slice, {
+    status: 206,
+    statusText: 'Partial Content',
+    headers: {
+      'Content-Type': mime,
+      'Content-Length': String(slice.byteLength),
+      'Content-Range': 'bytes ' + start + '-' + (start + slice.byteLength - 1) + '/' + data.byteLength,
+      'Accept-Ranges': 'bytes'
+    }
+  });
+}
+
+function okResponse(data, mime) {
+  return new Response(data, {
+    status: 200,
+    headers: {
+      'Content-Type': mime,
+      'Content-Length': String(data.byteLength),
+      'Cache-Control': 'no-cache',
+      'Accept-Ranges': 'bytes'
+    }
+  });
+}
+
+function notFound(path) {
+  return new Response('Not in ZIM: ' + path, {
+    status: 404,
+    headers: { 'Content-Type': 'text/plain' }
+  });
+}
+
+function noZim() {
+  return new Response('No ZIM loaded', {
+    status: 503,
+    headers: { 'Content-Type': 'text/plain' }
+  });
+}
+
+async function serveFromZim(viewerPath, request) {
+  try {
+    const reader = await getReader();
+    if (!reader) return noZim();
+    const entry = await reader.read(viewerPath);
+    if (!entry) return notFound(viewerPath);
+    const range = request.headers.get('range');
+    if (range) {
+      const rr = rangeResponse(entry.data, range, entry.mime);
+      if (rr) return rr;
+    }
+    return okResponse(entry.data, entry.mime);
+  } catch (err) {
+    console.error('[sw] ZIM lookup failed for', viewerPath, err);
+    return new Response('ZIM error: ' + (err && err.message || err), {
+      status: 500,
+      headers: { 'Content-Type': 'text/plain' }
+    });
+  }
+}
 
 self.addEventListener('fetch', (event) => {
   const req = event.request;
   if (req.method !== 'GET') return;
+
   const url = new URL(req.url);
 
-  // Tiles: network-first with cache fallback. Keeps the map fresh when we
-  // have signal, shows last-seen tiles when we don't.
-  if (/\.tile\.openstreetmap\.org$/i.test(url.hostname)) {
-    event.respondWith(
-      fetch(req).then((resp) => {
-        // Only cache successful opaque/basic responses
-        if (resp && resp.ok) {
-          const copy = resp.clone();
-          caches.open('streetzim-drive-tiles-v1').then((c) => c.put(req, copy));
+  // Only intercept within our own scope. Firebase assets outside /drive/
+  // (e.g. analytics for web/index.html) fall through to the network.
+  if (url.origin !== location.origin) return;
+  if (!url.pathname.startsWith('/drive/')) return;
+
+  // Viewer scope: /drive/viewer/*
+  const viewerPrefix = '/drive/viewer/';
+  if (url.pathname === viewerPrefix || url.pathname.startsWith(viewerPrefix)) {
+    const rest = url.pathname.slice(viewerPrefix.length);  // '' | 'index.html' | 'tiles/10/1/2.pbf' | ...
+    const firstSegment = rest.split('/')[0] || '';
+    if (VIEWER_SHELL_NAMES.has(firstSegment) && !rest.includes('/')) {
+      // Shell asset — serve from cache, network as fallback.
+      event.respondWith((async () => {
+        const cached = await caches.match(req);
+        if (cached) return cached;
+        try {
+          const net = await fetch(req);
+          if (net && net.ok) {
+            const copy = net.clone();
+            caches.open(SHELL_CACHE).then((c) => c.put(req, copy));
+          }
+          return net;
+        } catch (e) {
+          return notFound(rest);
         }
-        return resp;
-      }).catch(() => caches.match(req))
-    );
+      })());
+      return;
+    }
+    // Data path — serve from ZIM.
+    event.respondWith(serveFromZim(rest, req));
     return;
   }
 
-  // Shell: cache-first, refresh in background.
-  event.respondWith(
-    caches.match(req).then((cached) => {
-      const fetchPromise = fetch(req).then((resp) => {
-        if (resp && resp.ok && (url.origin === location.origin || url.hostname === 'unpkg.com')) {
-          const copy = resp.clone();
-          caches.open(SHELL_CACHE).then((c) => c.put(req, copy));
-        }
-        return resp;
-      }).catch(() => cached);
-      return cached || fetchPromise;
-    })
-  );
+  // /drive/ itself (picker page) and PWA shell assets: cache-first.
+  event.respondWith((async () => {
+    const cached = await caches.match(req);
+    if (cached) return cached;
+    try {
+      const net = await fetch(req);
+      if (net && net.ok) {
+        const copy = net.clone();
+        caches.open(SHELL_CACHE).then((c) => c.put(req, copy));
+      }
+      return net;
+    } catch (e) {
+      return cached || notFound(url.pathname);
+    }
+  })());
 });

--- a/web/drive/zim-reader.js
+++ b/web/drive/zim-reader.js
@@ -1,0 +1,292 @@
+// StreetZim Drive — in-browser ZIM reader.
+//
+// Consumed by the service worker (importScripts) to turn a local .zim
+// Blob into HTTP responses. Exposes StreetZimReader on the global scope.
+//
+// Supported: ZIM v5/v6 with uncompressed (flag 1/2) and zstd (flag 5)
+//            clusters. Requires fzstd (loaded alongside via importScripts
+//            or <script>) for zstd.
+// Not yet:   xz clusters (throws), full-text search, title index,
+//            redirect chains > 1 hop.
+//
+// Format ref: https://wiki.openzim.org/wiki/ZIM_file_format
+// If we hit weird ZIMs in the wild, cross-reference kiwix-js:
+//   https://github.com/kiwix/kiwix-js/tree/main/app/js  (zimfile.js,
+//   zimArchive.js, zimDirEntry.js). Its reader handles more edge cases
+//   than we need here (split archives, titleList search, xz clusters).
+
+(function(global) {
+  'use strict';
+
+  const MAGIC = 0x44D495A;
+
+  function u8 (v, o) { return v.getUint8(o); }
+  function u16(v, o) { return v.getUint16(o, true); }
+  function u32(v, o) { return v.getUint32(o, true); }
+  function u64(v, o) {
+    // Safe up to 2^53 ≈ 9 PB — plenty for any ZIM we'll see.
+    return v.getUint32(o, true) + v.getUint32(o + 4, true) * 0x100000000;
+  }
+
+  function readCString(view, offset) {
+    const u8a = new Uint8Array(view.buffer, view.byteOffset + offset,
+                               view.byteLength - offset);
+    let end = 0;
+    while (end < u8a.length && u8a[end] !== 0) end++;
+    const str = new TextDecoder('utf-8').decode(u8a.subarray(0, end));
+    return { str: str, nextOffset: offset + end + 1 };
+  }
+
+  class LRU {
+    constructor(limit) { this.limit = limit; this.map = new Map(); }
+    get(k) {
+      if (!this.map.has(k)) return undefined;
+      const v = this.map.get(k);
+      this.map.delete(k); this.map.set(k, v);
+      return v;
+    }
+    set(k, v) {
+      if (this.map.has(k)) this.map.delete(k);
+      this.map.set(k, v);
+      while (this.map.size > this.limit) {
+        this.map.delete(this.map.keys().next().value);
+      }
+    }
+  }
+
+  class ZimReader {
+    constructor(file) {
+      if (!file || typeof file.slice !== 'function') {
+        throw new Error('ZimReader: expected a File or Blob');
+      }
+      this.file = file;
+      this.size = file.size;
+      this.header = null;
+      this.mimeList = null;
+      this.clusterCache = new LRU(8);       // clusterNum → {data, extended}
+      this.blobCache = new LRU(512);        // "c:b"      → Uint8Array
+      this.entryCache = new LRU(1024);      // "ns/url"   → {mime, cluster, blob}
+    }
+
+    async _readRange(offset, length) {
+      if (offset < 0 || offset + length > this.size) {
+        throw new Error(`ZimReader: out-of-range read (${offset}+${length} of ${this.size})`);
+      }
+      return new Uint8Array(await this.file.slice(offset, offset + length).arrayBuffer());
+    }
+
+    async open() {
+      const buf = await this._readRange(0, 80);
+      const v = new DataView(buf.buffer);
+      const magic = u32(v, 0);
+      if (magic !== MAGIC) {
+        throw new Error('Not a ZIM file (magic=0x' + magic.toString(16) + ')');
+      }
+      this.header = {
+        majorVersion:   u16(v, 4),
+        minorVersion:   u16(v, 6),
+        articleCount:   u32(v, 24),
+        clusterCount:   u32(v, 28),
+        urlPtrPos:      u64(v, 32),
+        titlePtrPos:    u64(v, 40),
+        clusterPtrPos:  u64(v, 48),
+        mimeListPos:    u64(v, 56),
+        mainPage:       u32(v, 64),
+        layoutPage:     u32(v, 68),
+        checksumPos:    u64(v, 72)
+      };
+      await this._loadMimeList();
+      return this.header;
+    }
+
+    async _loadMimeList() {
+      const len = Math.max(0, this.header.urlPtrPos - this.header.mimeListPos);
+      const buf = await this._readRange(this.header.mimeListPos, Math.min(len, 65536));
+      const view = new DataView(buf.buffer);
+      const list = [];
+      let off = 0;
+      while (off < buf.length) {
+        const r = readCString(view, off);
+        if (r.str === '') break;
+        list.push(r.str);
+        off = r.nextOffset;
+      }
+      this.mimeList = list;
+    }
+
+    async _readUrlPointer(idx) {
+      const buf = await this._readRange(this.header.urlPtrPos + idx * 8, 8);
+      return u64(new DataView(buf.buffer), 0);
+    }
+
+    async _readClusterPointer(idx) {
+      const buf = await this._readRange(this.header.clusterPtrPos + idx * 8, 8);
+      return u64(new DataView(buf.buffer), 0);
+    }
+
+    async _readDirEntryAt(offset) {
+      // Over-read — DirEntries are typically < 512 B including URL + title.
+      // If a string ran past our buffer we re-fetch larger.
+      const initial = Math.min(1024, this.size - offset);
+      let buf = await this._readRange(offset, initial);
+      let v = new DataView(buf.buffer);
+      const mimeType = u16(v, 0);
+      const isRedirect = mimeType === 0xFFFF;
+      const isSpecial  = mimeType >= 0xFFFD;
+      const namespace = String.fromCharCode(u8(v, 3));
+      let headEnd = 8;
+      const extra = {};
+      if (isRedirect) {
+        extra.redirectIndex = u32(v, 8);
+        headEnd = 12;
+      } else if (!isSpecial) {
+        extra.clusterNumber = u32(v, 8);
+        extra.blobNumber    = u32(v, 12);
+        headEnd = 16;
+      }
+      let r = readCString(v, headEnd);
+      let url = r.str;
+      let nextOff = r.nextOffset;
+      if (nextOff >= buf.length && buf.length < this.size - offset) {
+        buf = await this._readRange(offset, Math.min(8192, this.size - offset));
+        v = new DataView(buf.buffer);
+        r = readCString(v, headEnd);
+        url = r.str; nextOff = r.nextOffset;
+      }
+      const tr = readCString(v, nextOff);
+      return Object.assign({
+        mimeType, namespace, url, title: tr.str,
+        isRedirect, isSpecial
+      }, extra);
+    }
+
+    // Binary search URL pointer list for an entry whose (ns, url) matches.
+    // ZIM sorts by (ns, url) ascending.
+    async findEntry(path, namespace) {
+      namespace = namespace || 'C';
+      const cacheKey = namespace + '/' + path;
+      const cached = this.entryCache.get(cacheKey);
+      if (cached !== undefined) return cached;
+
+      let lo = 0, hi = this.header.articleCount - 1;
+      while (lo <= hi) {
+        const mid = (lo + hi) >>> 1;
+        const off = await this._readUrlPointer(mid);
+        const de = await this._readDirEntryAt(off);
+        const cmp = cmpNsUrl(de.namespace, de.url, namespace, path);
+        if (cmp === 0) {
+          let resolved = de;
+          if (de.isRedirect) {
+            const targetOff = await this._readUrlPointer(de.redirectIndex);
+            resolved = await this._readDirEntryAt(targetOff);
+            if (resolved.isRedirect || resolved.isSpecial) {
+              this.entryCache.set(cacheKey, null);
+              return null;
+            }
+          }
+          if (resolved.isSpecial) {
+            this.entryCache.set(cacheKey, null);
+            return null;
+          }
+          const info = {
+            mime: this.mimeList[resolved.mimeType] || 'application/octet-stream',
+            cluster: resolved.clusterNumber,
+            blob: resolved.blobNumber,
+            namespace: resolved.namespace,
+            url: resolved.url
+          };
+          this.entryCache.set(cacheKey, info);
+          return info;
+        }
+        if (cmp < 0) lo = mid + 1;
+        else         hi = mid - 1;
+      }
+      this.entryCache.set(cacheKey, null);
+      return null;
+    }
+
+    async _loadCluster(clusterNum) {
+      const cached = this.clusterCache.get(clusterNum);
+      if (cached) return cached;
+
+      const start = await this._readClusterPointer(clusterNum);
+      const end = (clusterNum + 1 < this.header.clusterCount)
+        ? await this._readClusterPointer(clusterNum + 1)
+        : this.header.checksumPos;
+      const raw = await this._readRange(start, end - start);
+      const info = raw[0];
+      const compression = info & 0x0F;
+      const extended = (info & 0x10) !== 0;
+      let payload;
+      if (compression === 1 || compression === 2) {
+        payload = raw.subarray(1);
+      } else if (compression === 5) {
+        if (!global.fzstd || typeof global.fzstd.decompress !== 'function') {
+          throw new Error('zstd decoder (fzstd) not loaded');
+        }
+        payload = global.fzstd.decompress(raw.subarray(1));
+      } else if (compression === 4) {
+        throw new Error('xz-compressed ZIMs are not supported');
+      } else {
+        throw new Error('Unknown cluster compression: ' + compression);
+      }
+      const cluster = { data: payload, extended };
+      this.clusterCache.set(clusterNum, cluster);
+      return cluster;
+    }
+
+    async _readBlob(clusterNum, blobNum) {
+      const key = clusterNum + ':' + blobNum;
+      const cached = this.blobCache.get(key);
+      if (cached) return cached;
+
+      const cluster = await this._loadCluster(clusterNum);
+      const { data, extended } = cluster;
+      const v = new DataView(data.buffer, data.byteOffset, data.byteLength);
+      const wordSize = extended ? 8 : 4;
+      const readOff = extended
+        ? (o) => v.getUint32(o, true) + v.getUint32(o + 4, true) * 0x100000000
+        : (o) => v.getUint32(o, true);
+      const firstOffset = readOff(0);
+      const numBlobs = (firstOffset / wordSize) - 1;
+      if (blobNum < 0 || blobNum >= numBlobs) {
+        throw new Error('blobNumber ' + blobNum + ' out of range (' + numBlobs + ')');
+      }
+      const start = readOff(blobNum * wordSize);
+      const stop  = readOff((blobNum + 1) * wordSize);
+      const out = data.subarray(start, stop);
+      this.blobCache.set(key, out);
+      return out;
+    }
+
+    // Main entry point — look up a content path. Returns null if not found.
+    async read(path, namespace) {
+      // Normalize: strip leading slash / "./"; percent-decode (tiles use
+      // percent-encoding for spaces in font names etc.).
+      path = String(path || '').replace(/^\.?\//, '');
+      try { path = decodeURIComponent(path); } catch (_) { /* keep raw */ }
+      const entry = await this.findEntry(path, namespace);
+      if (!entry) return null;
+      const data = await this._readBlob(entry.cluster, entry.blob);
+      return { mime: entry.mime, data: data, url: entry.url };
+    }
+
+    get info() {
+      if (!this.header) return null;
+      return {
+        version: this.header.majorVersion + '.' + this.header.minorVersion,
+        articles: this.header.articleCount,
+        clusters: this.header.clusterCount,
+        sizeMB: (this.size / (1024 * 1024)).toFixed(1)
+      };
+    }
+  }
+
+  function cmpNsUrl(aNs, aUrl, bNs, bUrl) {
+    if (aNs !== bNs) return aNs < bNs ? -1 : 1;
+    if (aUrl === bUrl) return 0;
+    return aUrl < bUrl ? -1 : 1;
+  }
+
+  global.StreetZimReader = ZimReader;
+})(typeof self !== 'undefined' ? self : globalThis);


### PR DESCRIPTION
## Summary

- Adds **Drive / Walk / Bike** mode buttons to the routing panel. Each launches the existing follow-the-route HUD with a mode-appropriate camera preset (pitch/zoom) and ETA speed; drive uses the A*-computed car time, walk and bike override at 1.4 m/s and 4.5 m/s.
- Bumps **MapLibre 5.20.0 → 5.23.0** in `create_osm_zim.py` so newly-built ZIMs match the PWA.
- Ships `/drive/` as a **Firebase-hostable PWA** that renders the existing viewer from a **local `.zim` file the user picks**, with zero network needed after install. Reuses `resources/viewer/index.html` unchanged — a service worker intercepts every viewer fetch (tiles, fonts, map-config.json, routing graph, search data) and answers it from the ZIM via a minimal in-browser reader.
- Adds a design doc at `docs/driving-mode-road-class-warnings.md` for the deferred "warn when Walk/Bike on a motorway" feature.

## Architecture (PWA)

```
web/drive/
├── index.html        picker page — showOpenFilePicker (Chromium) /
│                     <input type=file> fallback (iOS Safari); stashes
│                     the Blob in IndexedDB via SW postMessage, then
│                     redirects to /drive/viewer/
├── sw.js             intercepts /drive/viewer/* — shell from Cache API,
│                     all other paths via the ZIM reader; supports HTTP
│                     Range so MapLibre tile fetches get proper 206s
├── zim-reader.js     ZIM v5/v6 parser: header, URL-ptr binary search,
│                     dir-entry decode, zstd cluster decompression via
│                     fzstd. LRU caches for clusters, blobs, entries.
│                     Header/dirent/compression-flag layouts cross-checked
│                     against the ZIM spec and kiwix-js.
├── fzstd.js          ← generated (gitignored), pulled from unpkg
├── viewer/           ← generated (gitignored)
│  ├── index.html     copy of resources/viewer/index.html
│  └── maplibre-gl.{js,css}
scripts/sync-drive-viewer.sh   populates the generated files above
firebase.json        predeploy hook runs the sync script; cache + MIME
                     headers tuned per asset (sw.js = no-cache, fzstd +
                     MapLibre = long cache)
```

## Test plan

- [ ] `firebase deploy --only hosting` runs `scripts/sync-drive-viewer.sh` via the predeploy hook and publishes to streetzim.web.app.
- [ ] On a phone: visit `/drive/`, Add to Home Screen, pick a `.zim` you've downloaded — verify it redirects into the viewer and tiles render.
- [ ] Airplane-mode test: relaunch the home-screen app with no network; verify the viewer still boots and tiles still render (all served from the local ZIM).
- [ ] Open the Route panel, plan a route, tap each of Drive / Walk / Bike in turn — verify camera preset + ETA update per mode and that EXIT restores the prior camera.
- [ ] In-ZIM viewer smoke test: build a fresh ZIM via `create_osm_zim.py` (MapLibre 5.23), open in Kiwix, verify Drive/Walk/Bike still work offline.
- [ ] Chrome DevTools → Sensors → spoof a location along the route; confirm HUD distance ticks down, bearing matches heading when velocity > 1 m/s.

## Deferred (documented, not in this PR)

Road-class warnings for Walk/Bike when the planned route uses motorway / trunk segments. See `docs/driving-mode-road-class-warnings.md` for the proposed SZRG v4 edge format, baker/viewer changes, and scope estimate.

## Branch note

Branch name `claude/driving-mode-pwa-zim-reader` predates the decision to reuse the existing viewer rather than rewrite it — the PR still delivers on the original intent (local-ZIM PWA), just by plumbing under the canonical viewer.

https://claude.ai/code/session_01K1Rt53qw7nZxFayx1ZHDTB