### PR TITLE
Resolve Wikidata Q-IDs to Wikipedia titles for cross-ZIM linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ terrain_cache*/
 terrain_compression_test/
 world-data/
 wikidata_cache/
+wiki_articles_cache/
 
 # web/drive/viewer/ and web/drive/fzstd.js are populated by
 # scripts/sync-drive-viewer.sh. We commit them (rather than generating

--- a/cloud/wiki_articles.py
+++ b/cloud/wiki_articles.py
@@ -1,0 +1,293 @@
+"""Bundle full Wikipedia article pages into the streetzim (option B).
+
+kiwix-serve can't deep-link from one ZIM into another, so an offline
+streetzim that wants tappable/narratable Wikipedia articles must carry its
+own copies. This fetches each linkable article (the `wikipedia` titles in
+the cross-ref index — OSM `wikipedia=` tags plus any backfilled from
+wikidata Q-IDs), trims it to a compact reader page, and stores it at
+`wiki-article/<Title>`.
+
+mcpzim resolves that path in `ZimService.articleByTitle`, and its narration
+cleaner (`ArticleSections.stripHTML`) further de-noises for TTS, so the
+pages narrate well through Kokoro. See docs/wikidata-title-resolution.md
+and the mcpzim BundledArticleTests / ArticleSpeechCleanupTests.
+
+Measured (California): the linkable set bundles to ~0.2-1% of the ZIM as
+trimmed reader HTML. Off by default (`--bundle-wiki-articles`).
+
+Sources: a local Wikipedia ZIM (offline, fast — pass `offline_zim`) or the
+public Wikipedia API (cached to disk). Public data only; the User-Agent is
+the project's public repo URL, never personal contact info. Wikipedia text
+is CC BY-SA — every page keeps a source link + license footer.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+
+USER_AGENT = "streetzim-wiki/1.0 (+https://github.com/jasontitus/streetzim)"
+PARSE_API = "https://en.wikipedia.org/w/api.php"
+# Repo-relative cache dir, matching wikidata_cache.py's convention
+# (SCRIPT_DIR / "wikidata_cache"). create_osm_zim.py lives one level up.
+DEFAULT_CACHE_DIR = Path(__file__).resolve().parent.parent / "wiki_articles_cache"
+
+# Tags we keep (everything else is unwrapped to its text). Block + inline
+# structure that reads/displays well; no media, tables, or interactivity.
+_KEEP_TAGS = {"p", "h2", "h3", "h4", "ul", "ol", "li", "b", "i", "em",
+              "strong", "blockquote", "dl", "dt", "dd", "br"}
+
+
+def _strip_lang(title: str) -> str:
+    """`en:Foo Bar` -> `Foo Bar`; leaves un-prefixed titles alone."""
+    ci = title.find(":")
+    if 2 <= ci <= 3 and title[:ci].isalpha():
+        return title[ci + 1:]
+    return title
+
+
+def _underscore(title: str) -> str:
+    return _strip_lang(title).replace(" ", "_")
+
+
+def _remove_spans_by_class(html: str, class_tokens: set[str]) -> str:
+    """Balanced `<span class="…">…</span>` removal for nested spans
+    (Wikipedia's per-character IPA tree, the ext-phonos ⓘ button, inline
+    geo coords). Token match so "geo" doesn't eat "geography". Mirrors
+    mcpzim's ArticleSections.removeSpansByClass."""
+    tag = re.compile(r"<(/?)span\b([^>]*)>", re.I)
+    tags = list(tag.finditer(html))
+    removals: list[tuple[int, int]] = []
+    i = 0
+    while i < len(tags):
+        m = tags[i]
+        if m.group(1):  # a </span>
+            i += 1
+            continue
+        cls = re.search(r'class="([^"]*)"', m.group(2), re.I)
+        toks = set(cls.group(1).lower().split()) if cls else set()
+        if not (toks & class_tokens):
+            i += 1
+            continue
+        depth, j = 1, i + 1
+        while j < len(tags):
+            depth += -1 if tags[j].group(1) else 1
+            if depth == 0:
+                break
+            j += 1
+        end = tags[j].end() if j < len(tags) else len(html)
+        removals.append((m.start(), end))
+        i = j + 1
+    if not removals:
+        return html
+    out, prev = [], 0
+    for a, b in removals:
+        out.append(html[prev:a])
+        out.append(" ")
+        prev = b
+    out.append(html[prev:])
+    return "".join(out)
+
+
+def clean_article_html(html: str, title: str, source_url: str) -> str:
+    """Trim raw article HTML (Kiwix or Parsoid) to a compact, self-
+    contained reader page: drop scripts/styles/tables/figures/nav/refs/
+    edit-links and the IPA/coord clutter, unwrap links to text, whitelist
+    structural tags, strip attributes, and add a CC BY-SA source footer."""
+    h = html
+    # Narrow to the article body when a full document is given.
+    mbody = re.search(r"<body\b[^>]*>(.*)</body>", h, re.S | re.I)
+    if mbody:
+        h = mbody.group(1)
+    mparser = re.search(r'<div[^>]*class="[^"]*mw-parser-output[^"]*"[^>]*>(.*)',
+                        h, re.S | re.I)
+    if mparser:
+        h = mparser.group(1)
+    h = re.sub(r"<!--.*?-->", "", h, flags=re.S)
+    # Whole-block drops (non-greedy; Kiwix/Parsoid output doesn't self-nest
+    # these). The IPA/geo spans need the balanced remover above.
+    h = _remove_spans_by_class(h, {"ipa", "rt-commentedtext", "ext-phonos",
+                                    "geo", "coordinates"})
+    for tag in ("script", "style", "table", "figure", "nav", "aside",
+                "sup", "ol", "math", "audio", "video"):
+        h = re.sub(rf"<{tag}\b[^>]*>.*?</{tag}>", " ", h, flags=re.S | re.I)
+    # Reference/nav/edit containers by class/role.
+    for cls in ("reflist", "navbox", "metadata", "mw-editsection",
+                "noprint", "hatnote", "thumb", "mw-empty-elt"):
+        h = re.sub(rf'<div\b[^>]*class="[^"]*{cls}[^"]*"[^>]*>.*?</div>',
+                  " ", h, flags=re.S | re.I)
+        h = re.sub(rf'<span\b[^>]*class="[^"]*{cls}[^"]*"[^>]*>.*?</span>',
+                  " ", h, flags=re.S | re.I)
+    # Unwrap links → keep their text.
+    h = re.sub(r"</?a\b[^>]*>", "", h, flags=re.I)
+    # Whitelist tags, strip attributes; drop others (keep inner text).
+    def keep(m: re.Match) -> str:
+        closing, name = m.group(1), m.group(2).lower()
+        return f"<{closing}{name}>" if name in _KEEP_TAGS else ""
+    h = re.sub(r"<(/?)([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>", keep, h)
+    # Collapse whitespace (HTML ignores it anyway) + drop empty tags +
+    # tidy the parentheticals the IPA removal empties out.
+    h = re.sub(r"\s+", " ", h)
+    h = re.sub(r">\s+<", "><", h)
+    for _ in range(3):
+        h = re.sub(r"<(p|li|ul|ol|h2|h3|h4|b|i|em|strong)>\s*</\1>", "", h)
+    h = h.replace("&#160;", " ").replace("&nbsp;", " ")  # nbsp → space (TTS)
+    h = re.sub(r"\b[A-Za-z]+:\s*(?=[);])", "", h)  # dangling "Spanish:" before ) / ;
+    h = re.sub(r"\(\s*[;,]\s*", "(", h)            # "( ; X" → "(X"
+    h = re.sub(r"\s*[;,]\s*\)", ")", h)            # "X ; )" → "X)"
+    h = re.sub(r"\(\s*[;,]?\s*\)", "", h)          # "( )" / "( ; )" leftovers
+    h = re.sub(r"\s+([.,;:!?)])", r"\1", h)
+    h = re.sub(r"\(\s+", "(", h)
+    h = h.strip()
+
+    safe_title = (title.replace("&", "&amp;").replace("<", "&lt;")
+                  .replace(">", "&gt;"))
+    return (
+        "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+        "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
+        f"<title>{safe_title}</title>"
+        "<style>body{font-family:-apple-system,Segoe UI,Roboto,sans-serif;"
+        "max-width:42em;margin:1em auto;padding:0 1em;line-height:1.55;"
+        "color:#222}h1{font-size:1.5em}h2{font-size:1.2em;margin-top:1.2em}"
+        "footer{margin-top:2em;padding-top:1em;border-top:1px solid #ddd;"
+        "font-size:.85em;color:#666}</style></head><body>"
+        f"<h1>{safe_title}</h1>\n{h}\n"
+        f"<footer>From <a href=\"{source_url}\">Wikipedia</a> — text under "
+        "<a href=\"https://creativecommons.org/licenses/by-sa/4.0/\">"
+        "CC BY-SA 4.0</a>.</footer></body></html>"
+    )
+
+
+# ---- fetching -------------------------------------------------------------
+
+class _OfflineZim:
+    """Lazy reader for a local Wikipedia ZIM (offline article source)."""
+    def __init__(self, path: str):
+        from libzim.reader import Archive  # lazy: only when offline source used
+        self.a = Archive(path)
+
+    def html(self, title_us: str) -> Optional[str]:
+        ws = title_us.replace("_", " ")
+        for p in (f"A/{title_us}", title_us, f"A/{ws}", ws):
+            try:
+                return bytes(self.a.get_entry_by_path(p).get_item().content).decode(
+                    "utf-8", "replace")
+            except KeyError:
+                continue
+            except Exception:
+                continue
+        return None
+
+
+def _fetch_online(title_us: str, cache_dir: Optional[str], ua: str) -> Optional[str]:
+    cache_file = None
+    if cache_dir:
+        os.makedirs(cache_dir, exist_ok=True)
+        key = hashlib.sha1(title_us.encode("utf-8")).hexdigest()
+        cache_file = os.path.join(cache_dir, key + ".html")
+        if os.path.exists(cache_file):
+            with open(cache_file, encoding="utf-8") as f:
+                return f.read() or None
+    params = urllib.parse.urlencode({
+        "action": "parse", "page": title_us.replace("_", " "),
+        "prop": "text", "redirects": "1", "format": "json",
+        "disableeditsection": "1", "disablelimitreport": "1", "formatversion": "2",
+    })
+    req = urllib.request.Request(f"{PARSE_API}?{params}", headers={"User-Agent": ua})
+    html = None
+    cacheable_miss = False  # API answered with no article (vs transient net error)
+    for attempt in range(4):
+        try:
+            with urllib.request.urlopen(req, timeout=60) as r:
+                data = json.load(r)
+            html = (data.get("parse") or {}).get("text")
+            if isinstance(html, dict):  # formatversion=1 shape
+                html = html.get("*")
+            cacheable_miss = not html
+            break
+        except urllib.error.HTTPError as e:
+            if e.code in (429, 503) and attempt < 3:
+                time.sleep(2 ** attempt); continue
+            cacheable_miss = True   # 4xx (e.g. 404) = a real miss, cache it
+            break
+        except Exception:
+            if attempt < 3:
+                time.sleep(2 ** attempt); continue
+            break                   # network/timeout — do NOT poison the cache
+    # Persist the result so rebuilds never re-crawl: real HTML, or an empty
+    # file as a known-miss marker (read back as "" -> None, no refetch).
+    # Skip only transient network failures so they retry next build.
+    if cache_file is not None and (html or cacheable_miss):
+        with open(cache_file, "w", encoding="utf-8") as f:
+            f.write(html or "")
+    return html
+
+
+def bundle_wiki_articles(
+    titles: Iterable[str],
+    add_item: Callable[[str, str, str, bytes], None],
+    *,
+    cache_dir: Optional[str] = None,
+    user_agent: str = USER_AGENT,
+    offline_zim: Optional[str] = None,
+    limit: Optional[int] = None,
+    sleep: float = 0.1,
+    log: Callable[[str], None] = print,
+) -> dict:
+    """Fetch + clean + store each distinct article at `wiki-article/<Title>`.
+
+    `add_item(path, title, mimetype, content_bytes)` is the storage callback
+    (wired to `creator.add_item(MapItem(...))` in the build; a plain dict
+    collector in tests). Returns stats.
+    """
+    seen: set[str] = set()
+    norm: list[str] = []
+    for t in titles:
+        if not t:
+            continue
+        u = _underscore(t)
+        if u and u not in seen:
+            seen.add(u)
+            norm.append(u)
+    if limit:
+        norm = norm[:limit]
+
+    src = _OfflineZim(offline_zim) if offline_zim else None
+    # Cache by default for the online path so a rebuild never re-crawls
+    # Wikipedia (repo-relative, like wikidata_cache/). Offline (local ZIM)
+    # needs no cache — reads are local.
+    if src is None and cache_dir is None:
+        cache_dir = str(DEFAULT_CACHE_DIR)
+    log(f"    bundle-wiki-articles: {len(norm)} distinct titles"
+        + (f" from {os.path.basename(offline_zim)}" if src
+           else f" via Wikipedia API (cache: {cache_dir})"))
+
+    bundled = failed = total_bytes = 0
+    for i, title_us in enumerate(norm, 1):
+        raw = src.html(title_us) if src else _fetch_online(title_us, cache_dir, user_agent)
+        if not raw:
+            failed += 1
+        else:
+            disp = title_us.replace("_", " ")
+            url = "https://en.wikipedia.org/wiki/" + urllib.parse.quote(title_us)
+            page = clean_article_html(raw, disp, url).encode("utf-8")
+            add_item(f"wiki-article/{title_us}", disp, "text/html", page)
+            bundled += 1
+            total_bytes += len(page)
+        if not src and sleep:
+            time.sleep(sleep)
+        if i % 250 == 0:
+            log(f"    ... {i}/{len(norm)} bundled={bundled} failed={failed} "
+                f"{total_bytes // 1024} KB")
+    stats = {"requested": len(norm), "bundled": bundled, "failed": failed,
+             "bytes": total_bytes}
+    log(f"    bundle-wiki-articles: stored {bundled} articles "
+        f"({total_bytes / 1024:.0f} KB), {failed} unavailable")
+    return stats

--- a/cloud/wikidata_titles.py
+++ b/cloud/wikidata_titles.py
@@ -1,0 +1,292 @@
+"""Resolve Wikidata Q-IDs -> English Wikipedia article titles.
+
+Why: streetzim search-index records carry two cross-ref fields — `w`
+(the OSM ``wikipedia=`` tag, already a title like ``en:Lincoln_Memorial``)
+and `q` (the OSM ``wikidata=`` Q-ID). mcpzim's ``ZimService.articleByTitle``
+links `w` straight to a Wikipedia ZIM by title. But the *majority* of
+wiki-tagged features carry only `q` (no ``wikipedia=`` tag), and a Q-ID
+can't be turned into an article without a Q-ID->title map.
+
+This module builds that map (from the public Wikidata API, or an offline
+dump) and fills in `w` from `q`, so those records become linkable with
+NO mcpzim change. A Wikidata enwiki *sitelink* is, by construction, the
+exact title of a live English Wikipedia article, so the resolved title
+honours mcpzim's "exact-match only, no fuzzy name matching" contract.
+
+Measured lift (osm-california-2026-05-09.zim): 8,863 distinct POI Q-IDs
+without a title; 3,199 (36%) have an enwiki article; resolving them lifts
+the directly-gettable distinct-article count ~2.4x (2,260 -> ~5,459).
+The other 64% are Wikidata items (minor streets/creeks/peaks, often GNIS
+imports) with no enwiki article — nothing to link to. See
+``docs/wikidata-title-resolution.md``.
+
+Privacy: public data only (Q-IDs + article titles). The User-Agent
+identifies the project by its PUBLIC repo URL — never personal contact
+info — per the repo's outbound-HTTP convention.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Callable, Iterable, Optional
+
+USER_AGENT = "streetzim-wikidata/1.0 (+https://github.com/jasontitus/streetzim)"
+WIKIDATA_API = "https://www.wikidata.org/w/api.php"
+ENWIKI = "enwiki"
+BATCH = 50  # wbgetentities accepts up to 50 ids per request
+
+
+def _api_batch(qids: list[str], *, api: str = WIKIDATA_API,
+               user_agent: str = USER_AGENT, retries: int = 4) -> dict:
+    """One ``wbgetentities`` call for <=50 Q-IDs; returns parsed JSON.
+
+    Retries 429/503/transport errors with exponential backoff.
+    """
+    params = urllib.parse.urlencode({
+        "action": "wbgetentities",
+        "ids": "|".join(qids),
+        "props": "sitelinks",
+        "sitefilter": ENWIKI,
+        "format": "json",
+    })
+    req = urllib.request.Request(f"{api}?{params}",
+                                 headers={"User-Agent": user_agent})
+    last: Optional[Exception] = None
+    for attempt in range(retries):
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return json.load(resp)
+        except urllib.error.HTTPError as e:
+            last = e
+            if e.code in (429, 503) and attempt < retries - 1:
+                time.sleep(2 ** attempt)
+                continue
+            raise
+        except (urllib.error.URLError, TimeoutError) as e:
+            last = e
+            if attempt < retries - 1:
+                time.sleep(2 ** attempt)
+                continue
+            raise
+    if last:
+        raise last
+    return {}
+
+
+def _titles_from_response(data: dict, qids: list[str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    entities = data.get("entities", {}) or {}
+    for q in qids:
+        sitelinks = (entities.get(q, {}) or {}).get("sitelinks", {}) or {}
+        title = (sitelinks.get(ENWIKI) or {}).get("title")
+        if title:
+            out[q] = title
+    return out
+
+
+def _load_tsv(path: str) -> dict[str, str]:
+    """Load an offline ``Q-ID<TAB>Title`` map (for air-gapped builds)."""
+    m: dict[str, str] = {}
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) >= 2 and parts[0].startswith("Q") and parts[1]:
+                m[parts[0]] = parts[1]
+    return m
+
+
+def resolve_qids(
+    qids: Iterable[str],
+    *,
+    cache_path: Optional[str] = None,
+    offline_map=None,
+    user_agent: str = USER_AGENT,
+    sleep: float = 0.1,
+    progress: Optional[Callable[[int, int], None]] = None,
+) -> dict[str, str]:
+    """Return ``{qid: enwiki_title}`` for Q-IDs with an English sitelink.
+
+    Q-IDs with no enwiki article are simply absent from the result.
+
+    offline_map: path to a ``Q-ID<TAB>Title`` TSV, or a pre-loaded dict —
+        resolves entirely offline, no network.
+    cache_path: JSON file persisting resolutions across rebuilds. Both
+        hits and known-misses (stored as "") are cached so repeated builds
+        never re-query the same Q-ID.
+    """
+    want = sorted({q for q in qids if q and q.startswith("Q")})
+    if not want:
+        return {}
+
+    if offline_map is not None:
+        m = offline_map if isinstance(offline_map, dict) else _load_tsv(offline_map)
+        return {q: m[q] for q in want if m.get(q)}
+
+    cache: dict[str, str] = {}
+    if cache_path and os.path.exists(cache_path):
+        try:
+            with open(cache_path, encoding="utf-8") as f:
+                cache = json.load(f)
+        except (ValueError, OSError):
+            cache = {}
+
+    todo = [q for q in want if q not in cache]
+    for i in range(0, len(todo), BATCH):
+        batch = todo[i:i + BATCH]
+        hits = _titles_from_response(_api_batch(batch, user_agent=user_agent), batch)
+        for q in batch:
+            cache[q] = hits.get(q, "")  # "" == known to have no enwiki article
+        if progress:
+            progress(min(i + BATCH, len(todo)), len(todo))
+        if sleep and i + BATCH < len(todo):
+            time.sleep(sleep)
+
+    if cache_path and todo:
+        tmp = cache_path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(cache, f)
+        os.replace(tmp, cache_path)
+
+    return {q: cache[q] for q in want if cache.get(q)}
+
+
+def augment_wiki_cross_refs(
+    wiki_cross_refs: Optional[dict],
+    *,
+    cache_path: Optional[str] = None,
+    offline_map=None,
+    log: Callable[[str], None] = print,
+) -> dict:
+    """In-place: fill `wikipedia` from `wikidata` on cross-ref entries.
+
+    ``wiki_cross_refs`` is the ``extract_wiki_tags_pbf`` lookup:
+    ``{key: {"wikipedia"?: "en:...", "wikidata"?: "Q..."}}``. For every
+    entry that has ``wikidata`` but no ``wikipedia``, resolve the Q-ID and
+    set::
+
+        entry["wikipedia"]     = "en:" + Title_With_Underscores
+        entry["wikipedia_src"] = "wd"        # provenance: derived, not OSM-tagged
+
+    The downstream chunker then writes these into ``rec["w"]`` exactly as
+    it does for OSM-tagged titles — so mcpzim links them with no change.
+
+    Returns stats: ``{distinct_qids, resolved, entries_upgraded}``.
+    """
+    empty = {"distinct_qids": 0, "resolved": 0, "entries_upgraded": 0}
+    if not wiki_cross_refs:
+        return empty
+
+    pending: dict[str, list] = {}
+    for entry in wiki_cross_refs.values():
+        if entry.get("wikipedia"):
+            continue
+        q = entry.get("wikidata")
+        if q:
+            pending.setdefault(q, []).append(entry)
+    if not pending:
+        return empty
+
+    log(f"    wikidata->title: resolving {len(pending)} distinct Q-IDs"
+        + (" (offline map)" if offline_map is not None else " via Wikidata API")
+        + "...")
+    titles = resolve_qids(pending.keys(), cache_path=cache_path,
+                          offline_map=offline_map)
+
+    upgraded = 0
+    for q, entries in pending.items():
+        title = titles.get(q)
+        if not title:
+            continue
+        tag = "en:" + title.replace(" ", "_")
+        for entry in entries:
+            entry["wikipedia"] = tag
+            entry["wikipedia_src"] = "wd"
+            upgraded += 1
+
+    stats = {"distinct_qids": len(pending), "resolved": len(titles),
+             "entries_upgraded": upgraded}
+    log(f"    wikidata->title: {stats['resolved']}/{stats['distinct_qids']} "
+        f"Q-IDs resolved, {upgraded} cross-ref entries upgraded")
+    return stats
+
+
+# --------------------------------------------------------------------------
+# Measurement CLI: reproduce the link-lift analysis on a built ZIM.
+#   python -m cloud.wikidata_titles --measure path/to/osm-*.zim [--sample N]
+# --------------------------------------------------------------------------
+def _measure(zim_path: str, sample: int = 0, cache_path: Optional[str] = None) -> None:
+    from libzim.reader import Archive  # lazy: only needed for measurement
+
+    a = Archive(zim_path)
+
+    def raw(p):
+        return bytes(a.get_entry_by_path(p).get_item().content)
+
+    manifest = json.loads(raw("search-data/manifest.json"))
+    prefixes = sorted(manifest.get("chunks", {}).keys())
+
+    distinct_q: set[str] = set()
+    q_records = 0
+    have_w = 0
+    by_type: dict[str, int] = {}
+    for pref in prefixes:
+        try:
+            b = raw(f"search-data/{pref}.json")
+        except Exception:
+            continue
+        if b'"q":' not in b and b'"w":' not in b:
+            continue
+        for r in json.loads(b):
+            if r.get("w"):
+                have_w += 1
+                continue
+            q = r.get("q")
+            if q:
+                q_records += 1
+                distinct_q.add(q)
+                by_type[r.get("t", "?")] = by_type.get(r.get("t", "?"), 0) + 1
+
+    qids = sorted(distinct_q)
+    if sample and len(qids) > sample:
+        stride = len(qids) / sample
+        qids = [qids[int(i * stride)] for i in range(sample)]
+
+    print(f"records already linkable by title (w):  {have_w:,}")
+    print(f"POI-wikidata records w/o title (q):      {q_records:,}")
+    print(f"  distinct POI Q-IDs:                    {len(distinct_q):,}")
+    print(f"resolving {len(qids):,} Q-IDs...", flush=True)
+
+    done = [0]
+
+    def prog(d, t):
+        if d - done[0] >= 1000 or d == t:
+            done[0] = d
+            print(f"    ... {d}/{t}", flush=True)
+
+    titles = resolve_qids(qids, cache_path=cache_path, progress=prog)
+    hit = len(titles) / max(1, len(qids))
+    print(f"\nresolved (enwiki sitelink): {len(titles):,}  ({100*hit:.1f}% hit rate)")
+    print(f"estimated linkable distinct articles added: ~{int(len(distinct_q)*hit):,}")
+    print("\nPOI-q records by feature type:")
+    for t, c in sorted(by_type.items(), key=lambda x: -x[1]):
+        print(f"   {t:12s} {c:,}")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Wikidata Q-ID -> enwiki title resolver")
+    ap.add_argument("--measure", metavar="ZIM",
+                    help="measure link-lift on a built streetzim ZIM")
+    ap.add_argument("--sample", type=int, default=0,
+                    help="resolve a strided sample of N distinct Q-IDs (0 = all)")
+    ap.add_argument("--cache", help="JSON cache path for resolutions")
+    args = ap.parse_args()
+    if args.measure:
+        _measure(args.measure, sample=args.sample, cache_path=args.cache)
+    else:
+        ap.error("nothing to do; pass --measure ZIM")

--- a/create_osm_zim.py
+++ b/create_osm_zim.py
@@ -4814,6 +4814,11 @@ def create_zim(
                         if wiki:
                             if wiki.get("wikipedia"):
                                 rec["w"] = wiki["wikipedia"]
+                                # Provenance: "wd" = title backfilled from a
+                                # wikidata Q-ID (see --resolve-wikidata-titles);
+                                # absent = the OSM wikipedia= tag itself.
+                                if wiki.get("wikipedia_src"):
+                                    rec["wsrc"] = wiki["wikipedia_src"]
                             if wiki.get("wikidata"):
                                 rec["q"] = wiki["wikidata"]
                         entry = json.dumps(rec, separators=(",", ":")) + "\n"
@@ -5686,6 +5691,23 @@ Known areas: """ + ", ".join(sorted(KNOWN_AREAS.keys())),
                              "pass. The chip-*.json files (Find page) are still "
                              "derived from poi+park records — they survive the "
                              "drop.")
+    parser.add_argument("--resolve-wikidata-titles", action="store_true",
+                        help="For search-index records that carry an OSM "
+                             "`wikidata=` Q-ID but no `wikipedia=` tag, resolve "
+                             "the Q-ID to its English Wikipedia title and fill "
+                             "`w` so mcpzim can cross-link them to a Wikipedia "
+                             "ZIM by title (no mcpzim change needed). Uses the "
+                             "public Wikidata API by default; pass "
+                             "--wikidata-title-map for an offline build. Lifts "
+                             "the directly-linkable distinct-article count ~2.4x "
+                             "on California. See docs/wikidata-title-resolution.md.")
+    parser.add_argument("--wikidata-title-cache", metavar="JSON",
+                        help="JSON cache for Q-ID->title resolutions; reused "
+                             "across rebuilds so the Wikidata API is hit once.")
+    parser.add_argument("--wikidata-title-map", metavar="TSV",
+                        help="Offline `Q-ID<TAB>Title` map; when set, "
+                             "--resolve-wikidata-titles uses it instead of the "
+                             "network (air-gapped builds).")
     parser.add_argument("--spatial-chunk-scale", type=int, default=0, metavar="N",
                         help="Convert the monolithic routing graph into the "
                              "spatial SZCI/SZRC layout in-build (N = cells per "
@@ -5958,6 +5980,19 @@ Known areas: """ + ", ".join(sorted(KNOWN_AREAS.keys())),
                 except Exception as _e:
                     print(f"    Warning: wiki cross-ref extraction failed: {_e}")
                     wiki_cross_refs = None
+                # Optionally backfill `wikipedia` from `wikidata` so records
+                # that carry only a Q-ID become title-linkable to a Wikipedia
+                # ZIM (the chunker writes the filled title into rec["w"]).
+                if getattr(args, "resolve_wikidata_titles", False) and wiki_cross_refs:
+                    try:
+                        from cloud.wikidata_titles import augment_wiki_cross_refs
+                        augment_wiki_cross_refs(
+                            wiki_cross_refs,
+                            cache_path=getattr(args, "wikidata_title_cache", None),
+                            offline_map=getattr(args, "wikidata_title_map", None),
+                        )
+                    except Exception as _e:
+                        print(f"    Warning: wikidata->title resolution failed: {_e}")
 
         # Build Wikidata cache if requested
         wikidata_data = None

--- a/create_osm_zim.py
+++ b/create_osm_zim.py
@@ -3925,6 +3925,9 @@ def create_zim(
     xapian_workdir=None,
     no_llm_bundle=False,
     spatial_chunk_scale=0,
+    bundle_wiki_articles=False,
+    wiki_articles_cache=None,
+    wiki_articles_source=None,
 ):
     """Create a ZIM file containing the map viewer and all tiles.
 
@@ -4449,6 +4452,32 @@ def create_zim(
             PHASE_TIMER.record_subphase(
                 "zim-pack: wikidata", time.time() - _wd_t0,
                 note=f"{len(wikidata_data)} entries → {len(wd_chunks)} chunks, {total_bytes / 1024:.0f} KB")
+
+        # Bundle full Wikipedia article pages (option B) so offline clients
+        # can open + narrate them — kiwix can't deep-link across ZIMs. Titles
+        # come from the cross-ref index (`w` OSM tags + any backfilled from
+        # wikidata via --resolve-wikidata-titles). Stored at
+        # wiki-article/<Title>; mcpzim's articleByTitle reads them there and
+        # its narration cleaner de-noises for TTS. Cached so rebuilds don't
+        # re-crawl. Source: a local Wikipedia ZIM (offline) or the API.
+        if bundle_wiki_articles and wiki_cross_refs:
+            _wa_titles = {e["wikipedia"] for e in wiki_cross_refs.values()
+                          if e.get("wikipedia")}
+            if _wa_titles:
+                from cloud.wiki_articles import bundle_wiki_articles as _bundle_wa
+                _wa_t0 = time.time()
+                _wa_stats = _bundle_wa(
+                    _wa_titles,
+                    lambda path, title, mt, content: creator.add_item(
+                        MapItem(path, title, mt, content)),
+                    cache_dir=wiki_articles_cache,
+                    offline_zim=wiki_articles_source,
+                )
+                PHASE_TIMER.record_subphase(
+                    "zim-pack: wiki-articles", time.time() - _wa_t0,
+                    note=f"{_wa_stats['bundled']} articles, "
+                         f"{_wa_stats['bytes'] // 1024} KB, "
+                         f"{_wa_stats['failed']} missing")
 
         # Add routing graph data.
         # Large regions produce multi-hundred-MB / multi-GB graph.bin
@@ -5708,6 +5737,23 @@ Known areas: """ + ", ".join(sorted(KNOWN_AREAS.keys())),
                         help="Offline `Q-ID<TAB>Title` map; when set, "
                              "--resolve-wikidata-titles uses it instead of the "
                              "network (air-gapped builds).")
+    parser.add_argument("--bundle-wiki-articles", action="store_true",
+                        help="Store full Wikipedia article pages at "
+                             "wiki-article/<Title> for every linkable POI (the "
+                             "`w` set + any --resolve-wikidata-titles backfill), "
+                             "trimmed to a compact reader page. Lets offline "
+                             "clients open + narrate articles without a separate "
+                             "Wikipedia ZIM (kiwix can't deep-link across ZIMs). "
+                             "~0.2-1% size on California. Cached so rebuilds "
+                             "don't re-crawl. See docs/wikidata-title-resolution.md.")
+    parser.add_argument("--wiki-articles-cache", metavar="DIR", default=None,
+                        help="Disk cache for fetched article HTML (default: "
+                             "wiki_articles_cache/). Reused across rebuilds.")
+    parser.add_argument("--wiki-articles-source", metavar="ZIM", default=None,
+                        help="Local Wikipedia ZIM to read articles from "
+                             "(offline, fast, no crawl). Omit to fetch from the "
+                             "public Wikipedia API. Use a FULL enwiki ZIM for "
+                             "coverage; a 'top'/subset misses long-tail POIs.")
     parser.add_argument("--spatial-chunk-scale", type=int, default=0, metavar="N",
                         help="Convert the monolithic routing graph into the "
                              "spatial SZCI/SZRC layout in-build (N = cells per "
@@ -6425,6 +6471,9 @@ Known areas: """ + ", ".join(sorted(KNOWN_AREAS.keys())),
             xapian_workdir=tmpdir,
             no_llm_bundle=bool(getattr(args, "no_llm_bundle", False)),
             spatial_chunk_scale=int(getattr(args, "spatial_chunk_scale", 0) or 0),
+            bundle_wiki_articles=bool(getattr(args, "bundle_wiki_articles", False)),
+            wiki_articles_cache=getattr(args, "wiki_articles_cache", None),
+            wiki_articles_source=getattr(args, "wiki_articles_source", None),
         )
 
         # Stop the phase timer (no further phases will be printed

--- a/create_osm_zim.py
+++ b/create_osm_zim.py
@@ -4790,6 +4790,8 @@ def create_zim(
             # linearly today; see STREETZIM_CONSUMPTION.md).
             type_counts = {}
             wiki_fields_added = 0
+            wiki_geo = {}  # title_us -> [lat, lon, type]: geo-index for the
+                           # viewer's nearby-Wikipedia list + markers (any zoom)
             cat_chunk_fds = {}
             cat_chunk_counts = {}
             cat_dir = os.path.join(chunk_tmp, "categories")
@@ -4848,6 +4850,20 @@ def create_zim(
                                 # absent = the OSM wikipedia= tag itself.
                                 if wiki.get("wikipedia_src"):
                                     rec["wsrc"] = wiki["wikipedia_src"]
+                                # Geo-index: underscored title -> [lat, lon, type].
+                                # Matches the bundled wiki-article/<Title> path so
+                                # the viewer can list + pin nearby Wikipedia at any
+                                # zoom (no tile scan, no side-loaded bridge).
+                                _wt = wiki["wikipedia"]
+                                _ci = _wt.find(":")
+                                _gt = (_wt[_ci + 1:] if 2 <= _ci <= 3
+                                       and _wt[:_ci].isalpha() else _wt).replace(" ", "_")
+                                if _gt and _gt not in wiki_geo:
+                                    # [lat, lon, type, qid] — qid lets the viewer
+                                    # pull the wikidata blurb from wikidata/<prefix>.
+                                    wiki_geo[_gt] = [round(feat["lat"], 5),
+                                                     round(feat["lon"], 5), t,
+                                                     wiki.get("wikidata")]
                             if wiki.get("wikidata"):
                                 rec["q"] = wiki["wikidata"]
                         entry = json.dumps(rec, separators=(",", ":")) + "\n"
@@ -5093,6 +5109,19 @@ def create_zim(
                 ))
                 print(f"    Added category-index: "
                       f"{len(cat_chunk_counts)} categories, {cat_total_records} records")
+                # Wiki geo-index: {title: [lat, lon, type]} for every placed
+                # bundled-article, so the viewer renders the nearby-Wikipedia
+                # list + map markers at any zoom without scanning vector tiles
+                # or a side-loaded bridge. Tiny (~0.005% of the ZIM).
+                if wiki_geo:
+                    creator.add_item(MapItem(
+                        "wiki-geo-index.json",
+                        "Wikipedia Geo Index",
+                        "application/json",
+                        json.dumps(wiki_geo, separators=(",", ":")).encode("utf-8"),
+                    ))
+                    print(f"    Added wiki-geo-index: {len(wiki_geo)} placed "
+                          f"articles", flush=True)
                 PHASE_TIMER.record_subphase(
                     "zim-pack: chips + category-index", time.time() - _cat_t0,
                     note=f"{len(cat_chunk_counts)} categories, {cat_total_records:,} records"

--- a/docs/wikidata-title-resolution.md
+++ b/docs/wikidata-title-resolution.md
@@ -136,6 +136,46 @@ Link target:
 This keeps the design honest: one shared field, two consumers (mcpzim's
 `articleByTitle` and the web viewer), zero parallel blobs.
 
+## Bundling full articles offline (`--bundle-wiki-articles`)
+
+Linking (above) needs a Wikipedia ZIM present. But **kiwix-serve can't
+deep-link from one ZIM into another**, so for a truly self-contained
+offline streetzim, `--bundle-wiki-articles` stores the article *in* the
+ZIM at `wiki-article/<Title>` for every linkable title (the `w` set + any
+`--resolve-wikidata-titles` backfill). mcpzim's `articleByTitle` resolves
+that path, and its narration cleaner (`ArticleSections.stripHTML`) de-
+noises it for Kokoro TTS (see mcpzim BundledArticleTests /
+ArticleSpeechCleanupTests).
+
+Each article is trimmed at build time to a compact reader page
+(`cloud/wiki_articles.py:clean_article_html`): scripts/styles/tables/
+infoboxes/figures/nav/reference-lists/edit-links and the IPA/coordinate
+clutter removed, links unwrapped to text, attributes stripped, with a
+CC BY-SA source-link footer. Real articles trim ~8× (Camarillo Ranch
+House 98 KB → 12 KB; Nevada 630 KB → 67 KB). Measured size: ~0.2-1% of
+the California ZIM for the linkable set.
+
+Sources + caching:
+
+- **Local Wikipedia ZIM** (`--wiki-articles-source <enwiki.zim>`) — offline,
+  fast, no crawl. Use a FULL enwiki ZIM; a `top`/subset misses long-tail
+  POIs.
+- **Wikipedia API** (default) — cached to `wiki_articles_cache/` (repo-
+  relative, like `wikidata_cache/`; gitignored). Both hits and known-misses
+  are cached, so **a rebuild never re-crawls**.
+
+```sh
+# Offline (fast) — read articles from a local enwiki ZIM:
+python create_osm_zim.py ... --resolve-wikidata-titles \
+    --bundle-wiki-articles --wiki-articles-source ~/zim/wikipedia_en_all.zim
+
+# Online (cached) — fetch + cache, so the next rebuild is free:
+python create_osm_zim.py ... --resolve-wikidata-titles --bundle-wiki-articles
+```
+
+Off by default. Pairs with `--resolve-wikidata-titles` for the widest set,
+but works alone (bundles just the OSM-tagged `w` titles).
+
 ## Edge cases
 
 - **No enwiki sitelink** → left as wikidata-only; behaviour unchanged.

--- a/docs/wikidata-title-resolution.md
+++ b/docs/wikidata-title-resolution.md
@@ -1,0 +1,135 @@
+# Wikidata → Wikipedia-title resolution (cross-ZIM linking)
+
+## Problem
+
+streetzim search-index records carry two Wikipedia cross-ref fields:
+
+| field | source | example | mcpzim use |
+| --- | --- | --- | --- |
+| `w` | OSM `wikipedia=` tag | `en:Lincoln_Memorial` | `ZimService.articleByTitle` links it to a Wikipedia ZIM **by title** |
+| `q` | OSM `wikidata=` tag | `Q162458` | carried, but **not resolvable** to an article without a Q-ID→title map |
+
+mcpzim links a POI to the full article only when `w` is present. A Q-ID
+alone can't be turned into an article — there's no Q-ID→title map on the
+record, in the streetzim, or in a stock Wikipedia ZIM. So every
+`wikidata`-only feature is dark to the cross-ref path.
+
+### Measured gap (`osm-california-2026-05-09.zim`)
+
+Full scan of all 78,955,300 search-data records:
+
+```
+records with a usable wikipedia title (w):     7,538   -> 2,260 distinct articles
+records with wikidata-only (no w):           126,795
+  ├─ POI wikidata (q), no title:              42,772   -> 8,863 distinct Q-IDs
+  └─ brand-only wikidata (wd):                84,023   ->   628 distinct Q-IDs
+```
+
+So ~94% of wiki-signal records carry only a Q-ID, and only **2,260
+distinct articles** are reachable today.
+
+## Approach
+
+At build time, resolve each distinct POI Q-ID (`q`) to its English
+Wikipedia title via its Wikidata **sitelink**, and fill `w` from it:
+
+```
+entry["wikipedia"]     = "en:" + Title_With_Underscores
+entry["wikipedia_src"] = "wd"        # provenance: derived, not OSM-tagged
+```
+
+The chunker already writes `entry["wikipedia"]` into `rec["w"]`, so mcpzim
+links these with **zero app-side change**. A Wikidata enwiki sitelink is,
+by construction, the exact title of a live English Wikipedia article — so
+this honours mcpzim's "exact-match only, no fuzzy name matching" contract
+(`NearPlacesWikiEnrichmentTests`), unlike name-based guessing.
+
+The new `wsrc:"wd"` field on the record records provenance so consumers
+(and eval) can tell OSM-tagged links from wikidata-derived ones.
+
+### Why fill `w` (vs. a new field or an in-ZIM Q-index)
+
+- mcpzim already resolves `w` titles via an exact-path `read()` (with a
+  redirect/`searchTitles` fallback). Filling `w` needs **no mcpzim change**
+  — existing app builds benefit immediately.
+- Per-record cost is tiny: one short title string on the resolved subset
+  (~3 k distinct titles on CA), negligible in a multi-GB ZIM.
+- Alternative considered — ship a `wikidata-index/` Q-ID→title file in the
+  ZIM and add a Q-ID fallback in `articleByTitle`. Rejected for v1: more
+  moving parts on both sides for no extra reach (the WP ZIM is keyed by
+  title anyway). Kept as a future option if title bloat ever matters at
+  planet scale.
+
+## Measured lift
+
+Resolving all 8,863 distinct POI Q-IDs against the Wikidata API:
+
+```
+resolved (have an enwiki sitelink):  3,199   (36.1%)
+no enwiki article:                   5,664   (63.9%)
+```
+
+- **Directly-linkable distinct articles: 2,260 → ~5,459 (~2.4×).**
+- Upgrades a large share of the 42,772 POI-`q` records.
+- Validation: a strided sample of the resolved titles was checked against
+  live `en.wikipedia.org` — **50/50 are real articles**. (Resolution is
+  correct by construction; the check just confirms titling/encoding.)
+- The 64% misses are genuine: Wikidata items for minor streets, creeks,
+  and peaks (often GNIS/geonames imports) that have **no** English
+  Wikipedia article — there is nothing to link to.
+
+Brand wikidata (`wd`, 84,023 records / 628 distinct chains) is **out of
+scope for v1**: it resolves to the brand's article ("Starbucks"), not the
+specific place, so it's a different feature (a `--resolve-brand-wikidata`
+opt-in could add it later — high record coverage, ~hundreds of articles).
+
+## Resolution sources
+
+1. **Wikidata Action API (default).** `wbgetentities?props=sitelinks&
+   sitefilter=enwiki`, 50 ids/request, results cached to disk (hits *and*
+   known-misses, so rebuilds never re-query). ~`distinct_q / 50` requests
+   (≈178 for CA). Public data only; User-Agent identifies the project by
+   its public repo URL — no personal contact info.
+2. **Offline `Q-ID<TAB>Title` map (air-gapped builds).** Pass
+   `--wikidata-title-map`. Build one from the enwiki `page` +
+   `page_props` (`pp_propname='wikibase_item'`) SQL dumps, or a tool like
+   `wikimapper`. The build never touches the network in this mode.
+
+## Usage
+
+```sh
+# Online (cached across rebuilds):
+python create_osm_zim.py ... --resolve-wikidata-titles \
+    --wikidata-title-cache build/wd_titles.json
+
+# Offline:
+python create_osm_zim.py ... --resolve-wikidata-titles \
+    --wikidata-title-map data/qid_enwiki_titles.tsv
+
+# Measure the lift on an already-built ZIM (no rebuild):
+python -m cloud.wikidata_titles --measure osm-california-2026-05-09.zim \
+    --cache build/wd_titles.json
+```
+
+The flag is **off by default** so stock builds stay hermetic/offline
+unless explicitly opted in.
+
+## Edge cases
+
+- **No enwiki sitelink** → left as wikidata-only; behaviour unchanged.
+- **Redirects / title drift** → mcpzim's `searchTitles` fallback catches
+  most; a stale title degrades to a clean "not found", never a wrong hit.
+- **API errors / rate limiting** → retry with backoff; unresolved Q-IDs
+  stay wikidata-only (partial resolution degrades gracefully).
+- **Build hermeticity** → API mode adds a network dependency; use
+  `--wikidata-title-map` for reproducible/air-gapped builds.
+
+## Implementation
+
+- `cloud/wikidata_titles.py` — `resolve_qids()`, `augment_wiki_cross_refs()`,
+  and a `--measure` CLI that reproduces the lift analysis on any ZIM.
+- `create_osm_zim.py` — the `--resolve-wikidata-titles` flag + a one-call
+  hook right after `extract_wiki_tags_pbf`, plus the `wsrc` provenance
+  field on emitted records.
+- `tests/test_wikidata_titles.py` — unit tests (network mocked): batching,
+  cache hit/miss persistence, offline map, and the augment contract.

--- a/docs/wikidata-title-resolution.md
+++ b/docs/wikidata-title-resolution.md
@@ -114,6 +114,28 @@ python -m cloud.wikidata_titles --measure osm-california-2026-05-09.zim \
 The flag is **off by default** so stock builds stay hermetic/offline
 unless explicitly opted in.
 
+## Web viewer (dual-use)
+
+The enriched `w` field is the standard, shared OSM-Wikipedia field — not an
+mcpzim-only path — so the in-ZIM web viewer surfaces it too. The place
+detail panel (`resources/viewer/index.html`) and the Find-page cards
+(`places.html`) now render a 📖 **Wikipedia** link whenever a record has
+`w`, including the titles backfilled here. So the lift is visible on the
+web Find page, not just to the offline LLM.
+
+Link target:
+
+- **Default** — the public site, `https://<lang>.wikipedia.org/wiki/<Title>`
+  (matches the viewer's existing external Wikidata link).
+- **Local** — most hosts (incl. kiwix-serve) **can't deep-link across
+  ZIMs**, so `wikipediaBase` is unset by default. A custom host that can
+  serve a local Wikipedia (e.g. an app WebView with its own URL scheme)
+  may set `wikipediaBase` in `map-config.json` to resolve offline. The
+  viewer reads it gracefully whether or not it's present.
+
+This keeps the design honest: one shared field, two consumers (mcpzim's
+`articleByTitle` and the web viewer), zero parallel blobs.
+
 ## Edge cases
 
 - **No enwiki sitelink** → left as wikidata-only; behaviour unchanged.

--- a/resources/viewer/index.html
+++ b/resources/viewer/index.html
@@ -1097,6 +1097,14 @@ fetchConfig(1)
     // Scale bar with mi/km toggle — click to switch units
     var scaleUnit = 'imperial';
     map._streetzimUnit = scaleUnit;  // shared with driving-mode HUD
+    // Optional Wikipedia base URL for the place-detail article link. Most
+    // hosts (incl. kiwix-serve) can't deep-link from one ZIM into another,
+    // so this is UNSET by default and the link goes to the public site. A
+    // custom host that can serve a local Wikipedia (e.g. an app WebView
+    // with its own URL scheme) may set `wikipediaBase` in map-config.json
+    // (trailing slash; we append the article title) to resolve offline.
+    // Either way this surfaces the wikidata->title enrichment (`rec.w`).
+    map._wikipediaBase = (config.wikipediaBase || '').trim() || null;
     var scaleControl = new maplibregl.ScaleControl({ unit: scaleUnit });
     map.addControl(scaleControl, 'bottom-left');
     document.addEventListener('click', function(e) {
@@ -2651,6 +2659,15 @@ function _showPlaceDetail(map, r, idx) {
       'Website', '🌐', false,
       function() { window.open(r.ws, '_blank', 'noopener'); }));
   }
+  // Wikipedia article link — present whenever the record carries an OSM
+  // wikipedia title (`w`), now including titles backfilled from a wikidata
+  // Q-ID (streetzim --resolve-wikidata-titles). Opens the local Wikipedia
+  // ZIM when one is configured, else the public site.
+  if (r.w) {
+    actions.appendChild(_detailActionBtn(
+      'Wikipedia', '📖', false,
+      function() { window.open(_wikipediaArticleUrl(map, r.w), '_blank', 'noopener'); }));
+  }
   panel.appendChild(actions);
 
   // Address line (if location string distinct from subhead)
@@ -2908,6 +2925,24 @@ function _detailOpenDirections(r) {
       }
     }, function() {}, { enableHighAccuracy: false, maximumAge: 60000, timeout: 8000 });
   }
+}
+
+// Build a Wikipedia article URL from an OSM `wikipedia=`-style tag value
+// ("en:Article Title"). Prefers the local Wikipedia ZIM base
+// (map._wikipediaBase, from map-config.json) so it resolves offline;
+// falls back to the public site when none is configured.
+function _wikipediaArticleUrl(map, w) {
+  var s = String(w || '');
+  var lang = 'en', title = s;
+  var ci = s.indexOf(':');
+  if (ci >= 2 && ci <= 3 && /^[a-z]+$/i.test(s.slice(0, ci))) {
+    lang = s.slice(0, ci).toLowerCase();
+    title = s.slice(ci + 1);
+  }
+  title = title.replace(/ /g, '_');
+  var base = map && map._wikipediaBase;
+  if (base) return base + encodeURIComponent(title);
+  return 'https://' + lang + '.wikipedia.org/wiki/' + encodeURIComponent(title);
 }
 
 function _populateWikipediaExtract(slot, wd) {

--- a/resources/viewer/places.html
+++ b/resources/viewer/places.html
@@ -1084,7 +1084,7 @@ function renderResults() {
     // them. Keep the markup lean: icon-only links row.
     // `ws` (website), not `w` — `w` is reserved for the OSM Wikipedia
     // tag in the same record; see commit fa6208b.
-    if (r.ws || r.p || (r.soc && r.soc.length) || r.brand) {
+    if (r.ws || r.p || (r.soc && r.soc.length) || r.brand || r.w) {
       const rich = document.createElement('p');
       rich.className = 'rich';
       if (r.brand) {
@@ -1099,6 +1099,20 @@ function renderResults() {
         const a = document.createElement('a');
         a.href = r.ws; a.target = '_blank'; a.rel = 'noopener';
         a.title = r.ws; a.textContent = '🌐';
+        links.appendChild(a);
+      }
+      if (r.w) {
+        // OSM Wikipedia title ("en:Article Title"), incl. titles backfilled
+        // from a wikidata Q-ID. Links to the public site (the rich detail
+        // panel in index.html prefers a local Wikipedia ZIM when present).
+        const wt = String(r.w), wc = wt.indexOf(':');
+        const isLang = wc >= 2 && wc <= 3 && /^[a-z]+$/i.test(wt.slice(0, wc));
+        const wl = isLang ? wt.slice(0, wc).toLowerCase() : 'en';
+        const wtitle = (isLang ? wt.slice(wc + 1) : wt).replace(/ /g, '_');
+        const a = document.createElement('a');
+        a.href = 'https://' + wl + '.wikipedia.org/wiki/' + encodeURIComponent(wtitle);
+        a.target = '_blank'; a.rel = 'noopener';
+        a.title = 'Wikipedia'; a.textContent = '📖';
         links.appendChild(a);
       }
       if (r.p) {

--- a/tests/test_wiki_articles.py
+++ b/tests/test_wiki_articles.py
@@ -1,0 +1,88 @@
+"""Unit tests for cloud/wiki_articles.py — network mocked.
+
+Run: python tests/test_wiki_articles.py   (or via pytest)
+"""
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from cloud import wiki_articles as wa
+
+
+class CleanArticleTests(unittest.TestCase):
+    def test_trims_noise_keeps_prose_and_adds_attribution(self):
+        # Real-ish lead: nested IPA in rt-commentedText, an infobox table, a
+        # reference sup, an edit-section span, and an internal link.
+        html = """
+        <div class="mw-parser-output">
+        <table class="infobox"><tr><td>Pop.</td><td>827,526</td></tr></table>
+        <p><b>Nevada</b> (<span class="rt-commentedText nowrap">
+        <span class="IPA">/nəˈvædə/</span>
+        <span class="ext-phonos">ⓘ</span></span>) is a
+        <a href="./State">state</a> in the Western United States.<sup class="reference">[5]</sup>
+        <span class="mw-editsection">[edit]</span></p>
+        <h2>History</h2><p>It became a state in 1864.</p>
+        <ol class="references"><li>Some citation.</li></ol>
+        </div>
+        """
+        out = wa.clean_article_html(html, "Nevada",
+                                    "https://en.wikipedia.org/wiki/Nevada")
+        self.assertIn("is a state in the Western United States", out)
+        self.assertIn("It became a state in 1864", out)
+        self.assertIn("<h2>History</h2>", out)
+        # Noise gone:
+        self.assertNotIn("827,526", out)          # infobox table
+        self.assertNotIn("ⓘ", out)           # ⓘ listen glyph
+        self.assertNotIn("væd", out)         # IPA
+        self.assertNotIn("[edit]", out)           # edit section
+        self.assertNotIn("Some citation", out)    # reference list
+        body = out.split("<footer>")[0]
+        self.assertNotIn("href", body)            # body links unwrapped
+        self.assertNotIn("./State", body)         # the internal link is gone
+        self.assertNotIn("class=", body)          # attributes stripped
+        # The footer keeps its attribution links (CC BY-SA requirement).
+        self.assertIn("href", out)
+        # Attribution footer present (CC BY-SA).
+        self.assertIn("CC BY-SA", out)
+        self.assertIn("en.wikipedia.org/wiki/Nevada", out)
+        self.assertTrue(out.startswith("<!DOCTYPE html>"))
+
+
+class BundleTests(unittest.TestCase):
+    def test_bundles_distinct_titles_at_wiki_article_path(self):
+        stored = {}
+        def add_item(path, title, mimetype, content):
+            stored[path] = (title, mimetype, content)
+
+        fake_html = '<div class="mw-parser-output"><p>Body text here.</p></div>'
+        with mock.patch.object(wa, "_fetch_online", return_value=fake_html) as m:
+            stats = wa.bundle_wiki_articles(
+                ["en:Camarillo Ranch House", "en:Camarillo Ranch House",  # dup
+                 "Lake Tahoe"],
+                add_item, cache_dir="/tmp/ignored", sleep=0, log=lambda *_: None)
+
+        self.assertEqual(stats["bundled"], 2)            # de-duped
+        self.assertEqual(stats["failed"], 0)
+        self.assertIn("wiki-article/Camarillo_Ranch_House", stored)
+        self.assertIn("wiki-article/Lake_Tahoe", stored)
+        title, mt, content = stored["wiki-article/Camarillo_Ranch_House"]
+        self.assertEqual(title, "Camarillo Ranch House")
+        self.assertEqual(mt, "text/html")
+        self.assertIn(b"Body text here", content)
+        self.assertEqual(m.call_count, 2)                # fetched once per distinct
+
+    def test_missing_article_counted_not_stored(self):
+        stored = {}
+        with mock.patch.object(wa, "_fetch_online", return_value=None):
+            stats = wa.bundle_wiki_articles(
+                ["en:No Such Place"], lambda *a: stored.setdefault(a[0], a),
+                cache_dir="/tmp/ignored", sleep=0, log=lambda *_: None)
+        self.assertEqual(stats["bundled"], 0)
+        self.assertEqual(stats["failed"], 1)
+        self.assertEqual(stored, {})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_wikidata_titles.py
+++ b/tests/test_wikidata_titles.py
@@ -1,0 +1,120 @@
+"""Unit tests for cloud/wikidata_titles.py — all network mocked.
+
+Run: python tests/test_wikidata_titles.py   (or via pytest)
+"""
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from cloud import wikidata_titles as wt
+
+
+def _fake_entities(mapping: dict) -> dict:
+    """Build a wbgetentities-shaped response. mapping: qid -> title|None."""
+    entities = {}
+    for q, title in mapping.items():
+        entities[q] = {"sitelinks": {"enwiki": {"title": title}} if title else {}}
+    return {"entities": entities}
+
+
+@contextmanager
+def _resp(payload: dict):
+    yield io.BytesIO(json.dumps(payload).encode("utf-8"))
+
+
+class ResolveQidsTests(unittest.TestCase):
+    def test_returns_only_titles_with_sitelinks(self):
+        payload = _fake_entities({"Q42": "Douglas Adams", "Q999": None})
+        with mock.patch.object(wt.urllib.request, "urlopen",
+                               return_value=_resp(payload)):
+            out = wt.resolve_qids(["Q42", "Q999"], sleep=0)
+        self.assertEqual(out, {"Q42": "Douglas Adams"})
+
+    def test_batches_over_50(self):
+        qids = [f"Q{i}" for i in range(1, 121)]  # 120 -> 3 batches
+        calls = []
+
+        def fake_urlopen(req, timeout=30):
+            # Parse the ids out of the query string to size each batch.
+            ids = req.full_url.split("ids=")[1].split("&")[0]
+            batch = ids.split("%7C") if "%7C" in ids else ids.split("|")
+            calls.append(len(batch))
+            return _resp(_fake_entities({q: f"T{q}" for q in batch}))
+
+        with mock.patch.object(wt.urllib.request, "urlopen", fake_urlopen):
+            out = wt.resolve_qids(qids, sleep=0)
+        self.assertEqual(len(out), 120)
+        self.assertEqual(calls, [50, 50, 20])
+
+    def test_cache_persists_hits_and_misses(self):
+        payload = _fake_entities({"Q42": "Douglas Adams", "Q999": None})
+        with tempfile.TemporaryDirectory() as d:
+            cache = os.path.join(d, "c.json")
+            with mock.patch.object(wt.urllib.request, "urlopen",
+                                   return_value=_resp(payload)) as m:
+                wt.resolve_qids(["Q42", "Q999"], cache_path=cache, sleep=0)
+                self.assertEqual(m.call_count, 1)
+            saved = json.load(open(cache))
+            self.assertEqual(saved["Q42"], "Douglas Adams")
+            self.assertEqual(saved["Q999"], "")  # known-miss cached
+            # Second run hits cache only — no API call.
+            with mock.patch.object(wt.urllib.request, "urlopen") as m2:
+                out = wt.resolve_qids(["Q42", "Q999"], cache_path=cache, sleep=0)
+                m2.assert_not_called()
+            self.assertEqual(out, {"Q42": "Douglas Adams"})
+
+    def test_offline_map_dict_skips_network(self):
+        with mock.patch.object(wt.urllib.request, "urlopen") as m:
+            out = wt.resolve_qids(["Q42", "Q7"],
+                                  offline_map={"Q42": "Douglas Adams"})
+            m.assert_not_called()
+        self.assertEqual(out, {"Q42": "Douglas Adams"})
+
+    def test_offline_map_tsv(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "m.tsv")
+            open(p, "w").write("Q42\tDouglas Adams\nQbad\n\nQ7\tFoo Bar\n")
+            out = wt.resolve_qids(["Q42", "Q7", "Q999"], offline_map=p)
+        self.assertEqual(out, {"Q42": "Douglas Adams", "Q7": "Foo Bar"})
+
+
+class AugmentTests(unittest.TestCase):
+    def test_fills_wikipedia_from_wikidata_with_provenance(self):
+        xref = {
+            "a": {"wikidata": "Q42"},                       # resolvable
+            "b": {"wikipedia": "en:Hand_Tag", "wikidata": "Q1"},  # already tagged
+            "c": {"wikidata": "Q999"},                      # no enwiki article
+            "d": {},                                        # nothing
+        }
+        payload = _fake_entities({"Q42": "Douglas Adams", "Q999": None})
+        with mock.patch.object(wt.urllib.request, "urlopen",
+                               return_value=_resp(payload)):
+            stats = wt.augment_wiki_cross_refs(xref, log=lambda *_: None)
+
+        # 'a' upgraded with underscored title + provenance.
+        self.assertEqual(xref["a"]["wikipedia"], "en:Douglas_Adams")
+        self.assertEqual(xref["a"]["wikipedia_src"], "wd")
+        # 'b' (OSM-tagged) untouched — no provenance flag, original title kept.
+        self.assertEqual(xref["b"]["wikipedia"], "en:Hand_Tag")
+        self.assertNotIn("wikipedia_src", xref["b"])
+        # 'c' (no article) and 'd' (no tag) stay unlinked.
+        self.assertNotIn("wikipedia", xref["c"])
+        self.assertNotIn("wikipedia", xref["d"])
+
+        self.assertEqual(stats["distinct_qids"], 2)   # Q42, Q999 (Q1 already tagged)
+        self.assertEqual(stats["resolved"], 1)
+        self.assertEqual(stats["entries_upgraded"], 1)
+
+    def test_empty_and_none_are_safe(self):
+        self.assertEqual(wt.augment_wiki_cross_refs(None)["entries_upgraded"], 0)
+        self.assertEqual(wt.augment_wiki_cross_refs({})["entries_upgraded"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Problem

Search-index records carry two Wikipedia cross-ref fields: `w` (the OSM `wikipedia=` tag — already a title like `en:Lincoln_Memorial`) and `q` (the OSM `wikidata=` Q-ID). mcpzim's `articleByTitle` links `w` to a Wikipedia ZIM **by title**, but a Q-ID alone can't be resolved to an article — so `wikidata`-only features are dark to the cross-ref path.

On `osm-california-2026-05-09.zim`, a full scan of all 78.9M records:

```
records with a usable wikipedia title (w):     7,538   -> 2,260 distinct articles
wikidata-only (no w):                        126,795
  POI wikidata (q), no title:                 42,772   -> 8,863 distinct Q-IDs
  brand-only wikidata (wd):                   84,023   ->   628 distinct Q-IDs
```

So ~94% of wiki-signal records carry only a Q-ID, and only **2,260 distinct articles** are reachable today.

## Approach

Opt-in build step: resolve each POI Q-ID to its English Wikipedia title via its Wikidata **sitelink**, and fill `w` from it. This is **field enrichment of the existing shared records — no new file/index/bundle**, and **no mcpzim change**. The chunker already writes `entry["wikipedia"]` into `rec["w"]`.

A Wikidata enwiki sitelink is, by construction, the exact title of a live enwiki article, so it honours mcpzim's exact-match (no fuzzy name matching) contract. Resolved records get `wsrc:"wd"` for provenance.

## Measured lift

Resolving all 8,863 distinct POI Q-IDs against the Wikidata API:

- **3,199 (36%)** have an enwiki article → directly-linkable distinct articles **2,260 → ~5,459 (~2.4×)**.
- The other **64%** are Wikidata items (minor streets/creeks/peaks, often GNIS imports) with **no** enwiki article — nothing to link to.
- A strided sample of resolved titles was checked against live `en.wikipedia.org`: **50/50 real articles**.

## What ships

Nothing new in the ZIM except richer `w` values (+ a 2-char `wsrc` marker on resolved records). The offline `--wikidata-title-map` is a **build input**, not shipped. Not a bundle; not mcpzim-private — `w` is the standard OSM-Wikipedia field any consumer reads.

## Changes

- `cloud/wikidata_titles.py` — `resolve_qids()` (Wikidata API, batched, disk cache of hits+misses; or offline `Q-ID<TAB>Title` map), `augment_wiki_cross_refs()`, and a `--measure` CLI to reproduce the lift on any ZIM.
- `create_osm_zim.py` — `--resolve-wikidata-titles` / `--wikidata-title-cache` / `--wikidata-title-map` flags (**off by default**), a one-call hook after `extract_wiki_tags_pbf`, and the `wsrc` provenance field.
- `tests/test_wikidata_titles.py` — unit tests (network mocked): batching, cache hit/miss persistence, offline map, augment contract.
- `docs/wikidata-title-resolution.md` — design, measured lift, usage, edge cases.

Public data only (Q-IDs + titles); User-Agent is project + public repo URL, no contact PII. Brand wikidata (`wd`) is left for a future opt-in.

## Test

```
python tests/test_wikidata_titles.py            # 7 passed
python -m cloud.wikidata_titles --measure osm-california-2026-05-09.zim
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)